### PR TITLE
chore(docs): Remove Google references from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,6 @@
 
 We'd love to accept your patches and contributions to this project.
 
-## Before you begin
-
-### Review our community guidelines
-
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
-
 ## Contribution process
 
 ### Code reviews
@@ -33,11 +26,3 @@ Here are some additional things to keep in mind during the process:
 
 - **Test your changes.** Before you submit a pull request, make sure that your changes work as expected.
 - **Be patient.** It may take some time for your pull request to be reviewed and merged.
-
----
-
-## For Google Employees
-
-Complete the following steps to register your GitHub account and be added as a contributor to this repository.
-
-1. Register your GitHub account at [go/GitHub](http://go/github).


### PR DESCRIPTION
Fixes #250 🦕
