### PR TITLE
chore(pyproject.toml): change license to text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "a2a-sdk"
 dynamic = ["version"]
 description = "A2A Python SDK"
 readme = "README.md"
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 requires-python = ">=3.10"
 keywords = ["A2A", "A2A SDK", "A2A Protocol", "Agent2Agent", "Agent 2 Agent"]


### PR DESCRIPTION
`pip show a2a-sdk` was including the whole license file.

Changed to just the license name

