### PR TITLE
fix: FastAPI route request and response annotation

### DIFF
--- a/src/a2a/server/apps/jsonrpc/fastapi_app.py
+++ b/src/a2a/server/apps/jsonrpc/fastapi_app.py
@@ -9,7 +9,7 @@ from a2a.server.apps.jsonrpc.jsonrpc_app import (
     JSONRPCApplication,
 )
 from a2a.server.request_handlers.jsonrpc_handler import RequestHandler
-from a2a.types import AgentCard
+from a2a.types import A2ARequest, AgentCard, JSONRPCResponse
 from a2a.utils.constants import (
     AGENT_CARD_WELL_KNOWN_PATH,
     DEFAULT_RPC_URL,
@@ -71,7 +71,7 @@ class A2AFastAPIApplication(JSONRPCApplication):
         """
 
         @app.post(rpc_url)
-        async def handle_a2a_request(request: Request) -> Response:
+        async def handle_a2a_request(request: A2ARequest) -> JSONRPCResponse:
             return await self._handle_requests(request)
 
         @app.get(agent_card_url)


### PR DESCRIPTION
This PR updates the type annotations in the route to handle A2A requests route in `A2AFastAPIApplication`:
- Changed the request type from `Request` to `A2ARequest`
- Changed the response type from `Response` to `JSONRPCResponse`

This makes FastAPI’s Swagger UI much more useful. With these changes:
- The request body is properly shown in the docs, so the endpoint can be tested directly in Swagger.
- The response schema is now visible, giving developers a better idea of what to expect back.

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/f43c7691-b154-457c-9301-750990d65466" />

Fixes #274 
