### PR TITLE
feat(server): Add lock to TaskUpdater to prevent race conditions

### DIFF
--- a/src/a2a/server/tasks/task_updater.py
+++ b/src/a2a/server/tasks/task_updater.py
@@ -60,6 +60,7 @@ class TaskUpdater:
         async with self._lock:
             if self._terminal_state_reached:
                 raise RuntimeError(f"Task {self.task_id} is already in a terminal state.")
+            if state in self._terminal_states:
                 self._terminal_state_reached = True
                 final = True
 

--- a/src/a2a/server/tasks/task_updater.py
+++ b/src/a2a/server/tasks/task_updater.py
@@ -60,8 +60,8 @@ class TaskUpdater:
         async with self._lock:
             if self._terminal_state_reached:
                 raise RuntimeError(f"Task {self.task_id} is already in a terminal state.")
-            if state in self._terminal_states:
                 self._terminal_state_reached = True
+                final = True
 
             current_timestamp = timestamp if timestamp else datetime.now(timezone.utc).isoformat()
             await self.event_queue.enqueue_event(

--- a/src/a2a/server/tasks/task_updater.py
+++ b/src/a2a/server/tasks/task_updater.py
@@ -1,5 +1,6 @@
 import asyncio
 import uuid
+
 from datetime import datetime, timezone
 from typing import Any
 

--- a/src/a2a/server/tasks/task_updater.py
+++ b/src/a2a/server/tasks/task_updater.py
@@ -1,5 +1,5 @@
+import asyncio
 import uuid
-
 from datetime import datetime, timezone
 from typing import Any
 
@@ -33,6 +33,14 @@ class TaskUpdater:
         self.event_queue = event_queue
         self.task_id = task_id
         self.context_id = context_id
+        self._lock = asyncio.Lock()
+        self._terminal_state_reached = False
+        self._terminal_states = {
+            TaskState.completed,
+            TaskState.canceled,
+            TaskState.failed,
+            TaskState.rejected,
+        }
 
     async def update_status(
         self,
@@ -49,21 +57,25 @@ class TaskUpdater:
             final: If True, indicates this is the final status update for the task.
             timestamp: Optional ISO 8601 datetime string. Defaults to current time.
         """
-        current_timestamp = (
-            timestamp if timestamp else datetime.now(timezone.utc).isoformat()
-        )
-        await self.event_queue.enqueue_event(
-            TaskStatusUpdateEvent(
-                taskId=self.task_id,
-                contextId=self.context_id,
-                final=final,
-                status=TaskStatus(
-                    state=state,
-                    message=message,
-                    timestamp=current_timestamp,
-                ),
+        async with self._lock:
+            if self._terminal_state_reached:
+                raise RuntimeError(f"Task {self.task_id} is already in a terminal state.")
+            if state in self._terminal_states:
+                self._terminal_state_reached = True
+
+            current_timestamp = timestamp if timestamp else datetime.now(timezone.utc).isoformat()
+            await self.event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    taskId=self.task_id,
+                    contextId=self.context_id,
+                    final=final,
+                    status=TaskStatus(
+                        state=state,
+                        message=message,
+                        timestamp=current_timestamp,
+                    ),
+                )
             )
-        )
 
     async def add_artifact(  # noqa: PLR0913
         self,


### PR DESCRIPTION
# Description

This PR adds a lock to the `TaskUpdater` to prevent race conditions when updating tasks that are in a terminal state (e.g., completed, failed). This ensures updates are handled atomically, making task state management more robust.

### **File Changes**

* `src/a2a/server/tasks/task_updater.py`
* `tests/server/tasks/test_task_updater.py`

### **Benefits**

* **Robustness**: Prevents race conditions during concurrent task updates.
* **Stability**: Ensures reliable task execution in production.
* **Test Coverage**: Adds new tests for concurrent scenarios.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #278 🦕
