### PR TITLE
feat: refactor FastAPI route setup and docs

### DIFF
--- a/src/a2a/server/apps/jsonrpc/fastapi_app.py
+++ b/src/a2a/server/apps/jsonrpc/fastapi_app.py
@@ -70,8 +70,8 @@ class A2AFastAPIApplication(JSONRPCApplication):
             extended_agent_card_url: The URL for the authenticated extended agent card endpoint.
         """
 
-        app.get(agent_card_url)(self._handle_get_agent_card)
         app.post(rpc_url)(self._handle_requests)
+        app.get(agent_card_url)(self._handle_get_agent_card)
         
         if self.agent_card.supportsAuthenticatedExtendedCard:
             app.get(extended_agent_card_url)(

--- a/src/a2a/server/apps/jsonrpc/fastapi_app.py
+++ b/src/a2a/server/apps/jsonrpc/fastapi_app.py
@@ -70,21 +70,13 @@ class A2AFastAPIApplication(JSONRPCApplication):
             extended_agent_card_url: The URL for the authenticated extended agent card endpoint.
         """
 
-        @app.post(rpc_url)
-        async def handle_a2a_request(request: Request) -> Response:
-            return await self._handle_requests(request)
-
-        @app.get(agent_card_url)
-        async def get_agent_card(request: Request) -> Response:
-            return await self._handle_get_agent_card(request)
-
+        app.get(agent_card_url)(self._handle_get_agent_card)
+        app.post(rpc_url)(self._handle_requests)
+        
         if self.agent_card.supportsAuthenticatedExtendedCard:
-
-            @app.get(extended_agent_card_url)
-            async def get_extended_agent_card(request: Request) -> Response:
-                return await self._handle_get_authenticated_extended_agent_card(
-                    request
-                )
+            app.get(extended_agent_card_url)(
+                self._handle_get_authenticated_extended_agent_card
+            )
 
     def build(
         self,


### PR DESCRIPTION
# Description

## Summary

This PR improves the current implementation of `A2AFastAPIApplication` class that enables serving A2A endpoints using a FastAPI application. (#104)

### Implementation Details

Refactors the `add_routes_to_app` method in `src/a2a/server/apps/jsonrpc/fastapi_app.py` to simplify route definitions by:

* Directly associating handler methods with FastAPI route decorators
* Removing unnecessary nested async function definitions by directly passing handler methods (`self._handle_requests`, `self._handle_get_agent_card`, and `self._handle_get_authenticated_extended_agent_card`) to the FastAPI decorators (`app.post` and `app.get`)
* Enabling method descriptions to appear in Swagger documentation, improving developer experience

These changes make the code more readable, maintainable, and better integrated with FastAPI's documentation features.


### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/6b9487fe-010f-492d-98cf-9f28d0ad194e)
![image](https://github.com/user-attachments/assets/7fd5edd9-5849-427d-aa74-6cb392ad370b)

#### After
![image](https://github.com/user-attachments/assets/00e7265b-8f5f-4841-a76a-8445be8a3ee6)
![image](https://github.com/user-attachments/assets/6ffd81e7-646c-42fb-ab96-13807cbc00bd)

---

Continues #104 🦕
