### PR TITLE
Improve error handling in task creation

### DIFF
--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -15,7 +15,16 @@ def new_task(request: Message) -> Task:
 
     Returns:
         A new `Task` object initialized with 'submitted' status and the input message in history.
+    
+    Raises:
+        TypeError: If the message role is None.
+        ValueError: If the message parts are empty.
     """
+    if not request.role:
+        raise TypeError('Message role cannot be None')
+    if not request.parts:
+        raise ValueError('Message parts cannot be empty')
+        
     return Task(
         status=TaskStatus(state=TaskState.submitted),
         id=(request.taskId if request.taskId else str(uuid.uuid4())),

--- a/tests/utils/test_task.py
+++ b/tests/utils/test_task.py
@@ -3,6 +3,8 @@ import uuid
 
 from unittest.mock import patch
 
+from pydantic import ValidationError
+
 from a2a.types import Message, Part, Role, TextPart
 from a2a.utils.task import completed_task, new_task
 
@@ -112,6 +114,24 @@ class TestTask(unittest.TestCase):
             history=history,
         )
         self.assertEqual(task.history, history)
+
+    def test_new_task_invalid_message_empty_parts(self):
+        with self.assertRaises(ValueError):
+            new_task(
+                Message(
+                    role=Role.user,
+                    parts=[],
+                    messageId=str(uuid.uuid4()),
+                )
+            )
+
+    def test_new_task_invalid_message_none_role(self):
+        with self.assertRaises(ValidationError):
+            Message(
+                role=None,
+                parts=[Part(root=TextPart(text='test message'))],
+                messageId=str(uuid.uuid4()),
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description
This update improves the robustness of the `new_task` function by adding explicit error handling for invalid `Message` objects.

Previously, `new_task` did not validate its input, which could lead to unexpected `TypeError` or `ValueError` exceptions when a malformed `Message` was passed. This change introduces checks to ensure that a `Message` has a valid `role` and a non-empty `parts` list before a `Task` is created.

Additionally, this update includes corresponding unit tests to verify the new error handling and ensures that the correct exceptions are raised for invalid inputs.

**Changes:**
`src/a2a/utils/task.py`
`tests/utils/test_task.py`
