### PR TITLE
fix: Add validation for empty artifact lists in `completed_task`

### DIFF
--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -56,7 +56,9 @@ def completed_task(
         A `Task` object with status set to 'completed'.
     """
     if not artifacts or not all(isinstance(a, Artifact) for a in artifacts):
-        raise ValueError("artifacts must be a non-empty list of Artifact objects")
+        raise ValueError(
+            'artifacts must be a non-empty list of Artifact objects'
+        )
 
     if history is None:
         history = []

--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -55,6 +55,9 @@ def completed_task(
     Returns:
         A `Task` object with status set to 'completed'.
     """
+    if not artifacts or not all(isinstance(a, Artifact) for a in artifacts):
+        raise ValueError("artifacts must be a non-empty list of Artifact objects")
+
     if history is None:
         history = []
     return Task(

--- a/tests/utils/test_task.py
+++ b/tests/utils/test_task.py
@@ -4,7 +4,8 @@ import uuid
 from unittest.mock import patch
 
 import pytest
-from a2a.types import Message, Part, Role, TextPart, Artifact
+
+from a2a.types import Artifact, Message, Part, Role, TextPart
 from a2a.utils.task import completed_task, new_task
 
 
@@ -58,7 +59,12 @@ class TestTask(unittest.TestCase):
     def test_completed_task_status(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
+        artifacts = [
+            Artifact(
+                artifactId='artifact_1',
+                parts=[Part(root=TextPart(text='some content'))],
+            )
+        ]
         task = completed_task(
             task_id=task_id,
             context_id=context_id,
@@ -70,7 +76,12 @@ class TestTask(unittest.TestCase):
     def test_completed_task_assigns_ids_and_artifacts(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
+        artifacts = [
+            Artifact(
+                artifactId='artifact_1',
+                parts=[Part(root=TextPart(text='some content'))],
+            )
+        ]
         task = completed_task(
             task_id=task_id,
             context_id=context_id,
@@ -84,7 +95,12 @@ class TestTask(unittest.TestCase):
     def test_completed_task_empty_history_if_not_provided(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
+        artifacts = [
+            Artifact(
+                artifactId='artifact_1',
+                parts=[Part(root=TextPart(text='some content'))],
+            )
+        ]
         task = completed_task(
             task_id=task_id, context_id=context_id, artifacts=artifacts
         )
@@ -93,7 +109,12 @@ class TestTask(unittest.TestCase):
     def test_completed_task_uses_provided_history(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
+        artifacts = [
+            Artifact(
+                artifactId='artifact_1',
+                parts=[Part(root=TextPart(text='some content'))],
+            )
+        ]
         history = [
             Message(
                 role=Role.user,
@@ -134,21 +155,27 @@ class TestTask(unittest.TestCase):
             new_task(msg)
 
     def test_completed_task_empty_artifacts(self):
-        with pytest.raises(ValueError, match="artifacts must be a non-empty list of Artifact objects"):
+        with pytest.raises(
+            ValueError,
+            match='artifacts must be a non-empty list of Artifact objects',
+        ):
             completed_task(
-                task_id="task-123",
-                context_id="ctx-456",
+                task_id='task-123',
+                context_id='ctx-456',
                 artifacts=[],
-                history=[]
+                history=[],
             )
 
     def test_completed_task_invalid_artifact_type(self):
-        with pytest.raises(ValueError, match="artifacts must be a non-empty list of Artifact objects"):
+        with pytest.raises(
+            ValueError,
+            match='artifacts must be a non-empty list of Artifact objects',
+        ):
             completed_task(
-                task_id="task-123",
-                context_id="ctx-456",
-                artifacts=["not an artifact"],
-                history=[]
+                task_id='task-123',
+                context_id='ctx-456',
+                artifacts=['not an artifact'],
+                history=[],
             )
 
 

--- a/tests/utils/test_task.py
+++ b/tests/utils/test_task.py
@@ -3,7 +3,8 @@ import uuid
 
 from unittest.mock import patch
 
-from a2a.types import Message, Part, Role, TextPart
+import pytest
+from a2a.types import Message, Part, Role, TextPart, Artifact
 from a2a.utils.task import completed_task, new_task
 
 
@@ -57,7 +58,7 @@ class TestTask(unittest.TestCase):
     def test_completed_task_status(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = []  # Artifacts should be of type Artifact
+        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
         task = completed_task(
             task_id=task_id,
             context_id=context_id,
@@ -69,7 +70,7 @@ class TestTask(unittest.TestCase):
     def test_completed_task_assigns_ids_and_artifacts(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = []  # Artifacts should be of type Artifact
+        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
         task = completed_task(
             task_id=task_id,
             context_id=context_id,
@@ -83,7 +84,7 @@ class TestTask(unittest.TestCase):
     def test_completed_task_empty_history_if_not_provided(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = []  # Artifacts should be of type Artifact
+        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
         task = completed_task(
             task_id=task_id, context_id=context_id, artifacts=artifacts
         )
@@ -92,7 +93,7 @@ class TestTask(unittest.TestCase):
     def test_completed_task_uses_provided_history(self):
         task_id = str(uuid.uuid4())
         context_id = str(uuid.uuid4())
-        artifacts = []  # Artifacts should be of type Artifact
+        artifacts = [Artifact(artifactId="artifact_1", parts=[Part(root=TextPart(text="some content"))])]
         history = [
             Message(
                 role=Role.user,
@@ -131,6 +132,24 @@ class TestTask(unittest.TestCase):
                 messageId=str(uuid.uuid4()),
             )
             new_task(msg)
+
+    def test_completed_task_empty_artifacts(self):
+        with pytest.raises(ValueError, match="artifacts must be a non-empty list of Artifact objects"):
+            completed_task(
+                task_id="task-123",
+                context_id="ctx-456",
+                artifacts=[],
+                history=[]
+            )
+
+    def test_completed_task_invalid_artifact_type(self):
+        with pytest.raises(ValueError, match="artifacts must be a non-empty list of Artifact objects"):
+            completed_task(
+                task_id="task-123",
+                context_id="ctx-456",
+                artifacts=["not an artifact"],
+                history=[]
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This update addresses an issue where the `completed_task` function in `a2a/utils/task.py` did not perform any validation on the `artifacts` list. This could lead to unexpected behavior if an empty or invalid list was provided.

This change introduces a validation check to ensure that the `artifacts` list is a non-empty list of `Artifact` objects, raising a `ValueError` if the validation fails.

**Changes:**

- Modified `a2a/utils/task.py` to add a validation check for the `artifacts` parameter in the `completed_task` function.
- Updated `tests/utils/test_task.py` to include tests for the new validation logic, covering cases with empty lists and lists containing invalid items.
