### PR TITLE
fix: Add Input Validation for Empty Message Content

### DIFF
--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from a2a.types import Artifact, Message, Task, TaskState, TaskStatus
+from a2a.types import Artifact, Message, Task, TaskState, TaskStatus, TextPart
 
 
 def new_task(request: Message) -> Task:
@@ -18,12 +18,15 @@ def new_task(request: Message) -> Task:
 
     Raises:
         TypeError: If the message role is None.
-        ValueError: If the message parts are empty.
+        ValueError: If the message parts are empty or if any part has empty content.
     """
     if not request.role:
         raise TypeError('Message role cannot be None')
     if not request.parts:
         raise ValueError('Message parts cannot be empty')
+    for part in request.parts:
+        if isinstance(part.root, TextPart) and not part.root.text:
+            raise ValueError('Message parts cannot have empty content')
 
     return Task(
         status=TaskStatus(state=TaskState.submitted),

--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -26,7 +26,7 @@ def new_task(request: Message) -> Task:
         raise ValueError('Message parts cannot be empty')
     for part in request.parts:
         if isinstance(part.root, TextPart) and not part.root.text:
-            raise ValueError('Message parts cannot have empty content')
+            raise ValueError('TextPart content cannot be empty')
 
     return Task(
         status=TaskStatus(state=TaskState.submitted),

--- a/tests/utils/test_task.py
+++ b/tests/utils/test_task.py
@@ -144,7 +144,7 @@ class TestTask(unittest.TestCase):
                     messageId=str(uuid.uuid4()),
                 )
             )
-            
+
     def test_new_task_invalid_message_empty_content(self):
         with self.assertRaises(ValueError):
             new_task(

--- a/tests/utils/test_task.py
+++ b/tests/utils/test_task.py
@@ -144,6 +144,16 @@ class TestTask(unittest.TestCase):
                     messageId=str(uuid.uuid4()),
                 )
             )
+            
+    def test_new_task_invalid_message_empty_content(self):
+        with self.assertRaises(ValueError):
+            new_task(
+                Message(
+                    role=Role.user,
+                    parts=[Part(root=TextPart(text=''))],
+                    messageId=str(uuid.uuid4()),
+                )
+            )
 
     def test_new_task_invalid_message_none_role(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
# Description

Adding input validation to the `new_task` function in `a2a/utils/task.py`. The new validation checks if any `part` within a `Message` contains empty content (e.g., `TextPart(text='')`) and raises a `ValueError` if it does.

This enhancement improves the system's reliability by preventing the creation and processing of tasks with invalid or incomplete message data.

### Changes Made
- Updated the `new_task` function in `src/a2a/utils/task.py` to iterate through message parts and check for empty content.
- Added a new test case, `test_new_task_invalid_message_empty_content`, in `tests/utils/test_task.py` to ensure the validation works as expected.
