### PR TITLE
style: standardize property null checks to use ternary operators

### DIFF
--- a/src/a2a/server/agent_execution/context.py
+++ b/src/a2a/server/agent_execution/context.py
@@ -127,9 +127,7 @@ class RequestContext:
     @property
     def configuration(self) -> MessageSendConfiguration | None:
         """The `MessageSendConfiguration` from the request, if available."""
-        if not self._params:
-            return None
-        return self._params.configuration
+        return self._params.configuration if self._params else None
 
     @property
     def call_context(self) -> ServerCallContext | None:
@@ -139,9 +137,7 @@ class RequestContext:
     @property
     def metadata(self) -> dict[str, Any]:
         """Metadata associated with the request, if available."""
-        if not self._params:
-            return {}
-        return self._params.metadata or {}
+        return self._params.metadata or {} if self._params else {}
 
     def add_activated_extension(self, uri: str) -> None:
         """Add an extension to the set of activated extensions for this request.


### PR DESCRIPTION
# Description

## Summary
Standardizes property null check patterns across the codebase by converting early return style to ternary operator style for consistency.

## Changes
  - **RequestContext.configuration**: Converted from `if not self._params: return None` pattern to ternary operator
  - **RequestContext.metadata**: Converted from `if not self._params: return {}` pattern to ternary operator
---
Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)
