### PR TITLE
fix: relax protobuf dependency version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "pydantic>=2.11.3",
   "sse-starlette",
   "starlette",
-  "protobuf==5.29.5",
+  "protobuf>=5.29.5",
   "google-api-core>=1.26.0",
 ]
 


### PR DESCRIPTION
We want to use this in a project that requires `protobuf==6.31.1`. Version history indicates upgrading a2a-python to that version is not possible at the moment. Therefore, relax the required version to just be `>=5.29.5` (instead of `==`).

This does print a warning when using a2a-python with a (major) newer version, but my tests show that it works just fine. Better to live with the warning than not being able to use a2a-python at all.

This does not update the buf generation config as this would upgrade to newer proto requirements (and generate protos for newer versions).