### PR TITLE
fix: Correctly run tests with the requested Python version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,17 +40,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Set up test environment variables
         run: |
           echo "POSTGRES_TEST_DSN=postgresql+asyncpg://a2a:a2a_password@localhost:5432/a2a_test" >> $GITHUB_ENV
           echo "MYSQL_TEST_DSN=mysql+aiomysql://a2a:a2a_password@localhost:3306/a2a_test" >> $GITHUB_ENV
 
-      - name: Install uv
+      - name: Install uv for Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Add uv to PATH
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -195,7 +195,7 @@ class DefaultRequestHandler(RequestHandler):
             if task.status.state in TERMINAL_TASK_STATES:
                 raise ServerError(
                     error=InvalidParamsError(
-                        message=f'Task {task.id} is in terminal state: {task.status.state}'
+                        message=f'Task {task.id} is in terminal state: {task.status.state.value}'
                     )
                 )
 
@@ -437,7 +437,7 @@ class DefaultRequestHandler(RequestHandler):
         if task.status.state in TERMINAL_TASK_STATES:
             raise ServerError(
                 error=InvalidParamsError(
-                    message=f'Task {task.id} is in terminal state: {task.status.state}'
+                    message=f'Task {task.id} is in terminal state: {task.status.state.value}'
                 )
             )
 

--- a/tests/server/apps/jsonrpc/test_jsonrpc_app.py
+++ b/tests/server/apps/jsonrpc/test_jsonrpc_app.py
@@ -92,7 +92,7 @@ class TestJSONRPCApplicationSetup:  # Renamed to avoid conflict
         # This will fail at definition time if an abstract method is not implemented
         with pytest.raises(
             TypeError,
-            match="Can't instantiate abstract class IncompleteJSONRPCApp with abstract method build",
+            match=".*abstract class IncompleteJSONRPCApp .* abstract method '?build'?",
         ):
 
             class IncompleteJSONRPCApp(JSONRPCApplication):


### PR DESCRIPTION
The action "Test with Python 3.13" does not work as expected, all tests are run with Python 3.10.

For exemple, [this run](https://github.com/a2aproject/a2a-python/actions/runs/16851324550/job/47738005154) shows:

```
Test with Python 3.13
...
Run uv run pytest --cov=a2a --cov-report term --cov-fail-under=88
============================= test session starts ==============================
platform linux -- Python 3.10.18, pytest-8.4.1, pluggy-1.6.0
```

I modified the script to set `python-version` on the "Install uv" step, this is the one that really creates the Python installation.
Then I fixed the tests, they should work with all Pythons now.