### PR TITLE
revert: "fix: Add validation for transport types in `ClientFactory`"

### DIFF
--- a/src/a2a/client/client_factory.py
+++ b/src/a2a/client/client_factory.py
@@ -91,7 +91,7 @@ class ClientFactory:
             if GrpcTransport is None:
                 raise ImportError(
                     'To use GrpcClient, its dependencies must be installed. '
-                    'You can install them with \'pip install "a2a-sdk[grpc]"\'',
+                    'You can install them with \'pip install "a2a-sdk[grpc]"\''
                 )
             self.register(
                 TransportProtocol.grpc,
@@ -124,20 +124,6 @@ class ClientFactory:
           If there is no valid matching of the client configuration with the
           server configuration, a `ValueError` is raised.
         """
-        valid_transports = {member.value for member in TransportProtocol}
-        configured_transports = set(self._config.supported_transports)
-
-        invalid_transports = configured_transports.difference(valid_transports)
-        if invalid_transports:
-            invalid_str = ', '.join(
-                sorted(f"'{t}'" for t in invalid_transports)
-            )
-            valid_str = ', '.join(sorted(valid_transports))
-            raise ValueError(
-                f'Unsupported transport type(s) in ClientConfig: {invalid_str}. '
-                f'Valid types are: {valid_str}'
-            )
-
         server_preferred = card.preferred_transport or TransportProtocol.jsonrpc
         server_set = {server_preferred: card.url}
         if card.additional_interfaces:

--- a/tests/client/test_client_factory.py
+++ b/tests/client/test_client_factory.py
@@ -103,32 +103,3 @@ def test_client_factory_no_compatible_transport(base_agent_card: AgentCard):
     factory = ClientFactory(config)
     with pytest.raises(ValueError, match='no compatible transports found'):
         factory.create(base_agent_card)
-
-
-@pytest.mark.parametrize(
-    ('invalid_transports', 'expected_match'),
-    [
-        (
-            ['invalid-transport'],
-            "Unsupported transport type\\(s\\) in ClientConfig: 'invalid-transport'",
-        ),
-        (
-            ['invalid-1', 'another-bad-one'],
-            "Unsupported transport type\\(s\\) in ClientConfig: 'another-bad-one', 'invalid-1'",
-        ),
-    ],
-)
-def test_client_factory_invalid_transport_in_config(
-    base_agent_card: AgentCard, invalid_transports, expected_match
-):
-    """Verify that the factory raises an error for unknown transport types."""
-    config = ClientConfig(
-        httpx_client=httpx.AsyncClient(),
-        supported_transports=[
-            TransportProtocol.jsonrpc,
-            *invalid_transports,
-        ],
-    )
-    factory = ClientFactory(config)
-    with pytest.raises(ValueError, match=expected_match):
-        factory.create(base_agent_card)


### PR DESCRIPTION
Reverts a2aproject/a2a-python#396

This PR shouldn't have been merged as we don't want to limit the protocol to only JSON-RPC, gRPC, and REST Transports. (e.g. for proprietary transport protocols)

Reported by @yarolegovich

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE