### PR TITLE
fix: Add missing mime_type and name in proto conversion utils

### DIFF
--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -508,16 +508,18 @@ class FromProto:
     def file(
         cls, file: a2a_pb2.FilePart
     ) -> types.FileWithUri | types.FileWithBytes:
+        common_args = {
+            'mime_type': file.mime_type or None,
+            'name': file.name or None,
+        }
         if file.HasField('file_with_uri'):
             return types.FileWithUri(
                 uri=file.file_with_uri,
-                mime_type=file.mime_type,
-                name=file.name,
+                **common_args,
             )
         return types.FileWithBytes(
             bytes=file.file_with_bytes.decode('utf-8'),
-            mime_type=file.mime_type,
-            name=file.name,
+            **common_args,
         )
 
     @classmethod

--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -80,8 +80,16 @@ class ToProto:
         cls, file: types.FileWithUri | types.FileWithBytes
     ) -> a2a_pb2.FilePart:
         if isinstance(file, types.FileWithUri):
-            return a2a_pb2.FilePart(file_with_uri=file.uri)
-        return a2a_pb2.FilePart(file_with_bytes=file.bytes.encode('utf-8'))
+            return a2a_pb2.FilePart(
+                file_with_uri=file.uri,
+                mime_type=file.mime_type,
+                name=file.name
+            )
+        return a2a_pb2.FilePart(
+            file_with_bytes=file.bytes.encode('utf-8'),
+            mime_type=file.mime_type,
+            name=file.name,
+        )
 
     @classmethod
     def task(cls, task: types.Task) -> a2a_pb2.Task:
@@ -501,8 +509,16 @@ class FromProto:
         cls, file: a2a_pb2.FilePart
     ) -> types.FileWithUri | types.FileWithBytes:
         if file.HasField('file_with_uri'):
-            return types.FileWithUri(uri=file.file_with_uri)
-        return types.FileWithBytes(bytes=file.file_with_bytes.decode('utf-8'))
+            return types.FileWithUri(
+                uri=file.file_with_uri,
+                mime_type=file.mime_type,
+                name=file.name,
+            )
+        return types.FileWithBytes(
+            bytes=file.file_with_bytes.decode('utf-8'),
+            mime_type=file.mime_type,
+            name=file.name,
+        )
 
     @classmethod
     def task_or_message(

--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -81,9 +81,7 @@ class ToProto:
     ) -> a2a_pb2.FilePart:
         if isinstance(file, types.FileWithUri):
             return a2a_pb2.FilePart(
-                file_with_uri=file.uri,
-                mime_type=file.mime_type,
-                name=file.name
+                file_with_uri=file.uri, mime_type=file.mime_type, name=file.name
             )
         return a2a_pb2.FilePart(
             file_with_bytes=file.bytes.encode('utf-8'),

--- a/tests/utils/test_proto_utils.py
+++ b/tests/utils/test_proto_utils.py
@@ -25,7 +25,7 @@ def sample_message() -> types.Message:
                     file=types.FileWithUri(
                         uri='file:///test.txt',
                         name='test.txt',
-                        mime_type="text/plain",
+                        mime_type='text/plain',
                     ),
                 )
             ),

--- a/tests/utils/test_proto_utils.py
+++ b/tests/utils/test_proto_utils.py
@@ -22,7 +22,11 @@ def sample_message() -> types.Message:
             types.Part(root=types.TextPart(text='Hello')),
             types.Part(
                 root=types.FilePart(
-                    file=types.FileWithUri(uri='file:///test.txt')
+                    file=types.FileWithUri(
+                        uri='file:///test.txt',
+                        name='test.txt',
+                        mime_type="text/plain",
+                    ),
                 )
             ),
             types.Part(root=types.DataPart(data={'key': 'value'})),
@@ -148,6 +152,8 @@ class TestProtoUtils:
 
         # Test file part handling
         assert proto_msg.content[1].file.file_with_uri == 'file:///test.txt'
+        assert proto_msg.content[1].file.mime_type == 'text/plain'
+        assert proto_msg.content[1].file.name == 'test.txt'
 
         roundtrip_msg = proto_utils.FromProto.message(proto_msg)
         assert roundtrip_msg == sample_message


### PR DESCRIPTION
# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes the issue when using protoutils, mime type and file name are lost
