### PR TITLE
Update _base.py

### DIFF
--- a/src/a2a/_base.py
+++ b/src/a2a/_base.py
@@ -31,8 +31,6 @@ class A2ABaseModel(BaseModel):
 
     model_config = ConfigDict(
         # SEE: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.populate_by_name
-        validate_by_name=True,
-        validate_by_alias=True,
-        serialize_by_alias=True,
+        populate_by_name=True,
         alias_generator=to_camel_custom,
     )


### PR DESCRIPTION
Pydantic v2 中适配字段名和字段别名的方式，原始方式
    model_config = ConfigDict(
        # SEE: https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.populate_by_name
        validate_by_name=True,
        validate_by_alias=True,
        serialize_by_alias=True,
        alias_generator=to_camel_custom,
    )
会导致  实例化 AgentCard 方法的时候 报错
pydantic_core._pydantic_core.ValidationError: 2 validation errors for AgentCard defaultInputModes
  Field required [type=missing, input_value={'name': 'Hello World Age...ed_extended_card': True}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
defaultOutputModes

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
