### PR TITLE
fix: convert auth_required state in proto utils

### DIFF
--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -122,6 +122,8 @@ class ToProto:
                 return a2a_pb2.TaskState.TASK_STATE_FAILED
             case types.TaskState.input_required:
                 return a2a_pb2.TaskState.TASK_STATE_INPUT_REQUIRED
+            case types.TaskState.auth_required:
+                return a2a_pb2.TaskState.TASK_STATE_AUTH_REQUIRED
             case _:
                 return a2a_pb2.TaskState.TASK_STATE_UNSPECIFIED
 
@@ -568,6 +570,8 @@ class FromProto:
                 return types.TaskState.failed
             case a2a_pb2.TaskState.TASK_STATE_INPUT_REQUIRED:
                 return types.TaskState.input_required
+            case a2a_pb2.TaskState.TASK_STATE_AUTH_REQUIRED:
+                return types.TaskState.auth_required
             case _:
                 return types.TaskState.unknown
 


### PR DESCRIPTION
# Description

The A2A client is receiving `unknown` state over REST transport while it should receive `auth_required`.

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)
