### PR TITLE
feat: add JSON-RPC `method` to `ServerCallContext.state`

### DIFF
--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -337,6 +337,7 @@ class JSONRPCApplication(ABC):
 
             # 3) Build call context and wrap the request for downstream handling
             call_context = self._context_builder.build(request)
+            call_context.state['method'] = method
 
             request_id = specific_request.id
             a2a_request = A2ARequest(root=specific_request)

--- a/tests/server/apps/jsonrpc/test_jsonrpc_app.py
+++ b/tests/server/apps/jsonrpc/test_jsonrpc_app.py
@@ -289,6 +289,26 @@ class TestJSONRPCExtensions:
         call_context = mock_handler.on_message_send.call_args[0][1]
         assert call_context.requested_extensions == {'foo', 'bar', 'baz'}
 
+    def test_method_added_to_call_context_state(self, client, mock_handler):
+        response = client.post(
+            '/',
+            json=SendMessageRequest(
+                id='1',
+                params=MessageSendParams(
+                    message=Message(
+                        message_id='1',
+                        role=Role.user,
+                        parts=[Part(TextPart(text='hi'))],
+                    )
+                ),
+            ).model_dump(),
+        )
+        response.raise_for_status()
+
+        mock_handler.on_message_send.assert_called_once()
+        call_context = mock_handler.on_message_send.call_args[0][1]
+        assert call_context.state['method'] == 'message/send'
+
     def test_request_with_multiple_extension_headers(
         self, client, mock_handler
     ):


### PR DESCRIPTION
# Improvement

SDK users sometimes need to know which JSON-RPC method is being processed to adjust their implementation, e.g.:
* If the method is `message/send`, they may want to use `invoke()`/`run()` when calling their LLM API, and `stream()`/`run_streamed()` for `message/stream`. 

# Implementation

Added a `method` field to `ServerCallContext.state`, similar to `headers`.

# Tests

Added a small test to ensure that method parsing is correct.


Fixes #451 
