### PR TITLE
fix: jsonrpc client send streaming request header and timeout field

### DIFF
--- a/src/a2a/client/transports/jsonrpc.py
+++ b/src/a2a/client/transports/jsonrpc.py
@@ -147,7 +147,10 @@ class JsonRpcTransport(ClientTransport):
             context,
         )
 
-        modified_kwargs.setdefault('timeout', None)
+        modified_kwargs['timeout'] = self.httpx_client.timeout.as_dict().get(
+            'read', None
+        )
+        modified_kwargs['headers'] = dict(self.httpx_client.headers.items())
 
         async with aconnect_sse(
             self.httpx_client,


### PR DESCRIPTION
The underlying aconnect_sse library will overwrite the header and timeout of what's set in the httpx_client. 

From a user using adk a2a_remote_agent library, they would pass in these information in the httpx_client. I have tried this fix in my local setup.
