### PR TITLE
fix(rest): send historyLength=0 (avoid falsy omission)

### DIFF
--- a/src/a2a/client/transports/rest.py
+++ b/src/a2a/client/transports/rest.py
@@ -214,7 +214,7 @@ class RestTransport(ClientTransport):
         response_data = await self._send_get_request(
             f'/v1/tasks/{request.id}',
             {'historyLength': str(request.history_length)}
-            if request.history_length
+            if request.history_length is not None
             else {},
             modified_kwargs,
         )


### PR DESCRIPTION
**What**
Ensure `history_length=0` results in `?historyLength=0` being sent by the REST client.

**Why**
`0` was treated as falsy → the param was omitted → servers returned the full history.

**How**
Replace truthy check with explicit `is not None`.

**Ref**
- Permalink: https://github.com/a2aproject/a2a-python/blob/4a4b4a92d7fce6db02f397753ce3ec0dfcd8a597/src/a2a/client/transports/rest.py#L217

Fixes #479
