### PR TITLE
fix(client): `A2ACardResolver.get_agent_card` will auto-populate with `agent_card_path` when `relative_card_path` is empty

### DIFF
--- a/src/a2a/client/card_resolver.py
+++ b/src/a2a/client/card_resolver.py
@@ -53,7 +53,7 @@ class A2ACardResolver:
         Args:
             relative_card_path: Optional path to the agent card endpoint,
                 relative to the base URL. If None, uses the default public
-                agent card path.
+                agent card path. Use `'/'` for an empty path.
             http_kwargs: Optional dictionary of keyword arguments to pass to the
                 underlying httpx.get request.
 


### PR DESCRIPTION
- Previously, it would only override with the default path when `relative_card_path` is `None`
- Developer Experience Improvement when `urlparse` or similar libraries are used.