### PR TITLE
fix: null-pointer when message send configuration is provided with no history limit

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -346,7 +346,10 @@ class DefaultRequestHandler(RequestHandler):
 
         if isinstance(result, Task):
             self._validate_task_id_match(task_id, result.id)
-            if params.configuration and params.configuration.history_length is not None:
+            if (
+                params.configuration
+                and params.configuration.history_length is not None
+            ):
                 result = apply_history_length(
                     result, params.configuration.history_length
                 )

--- a/tests/server/request_handlers/test_default_request_handler.py
+++ b/tests/server/request_handlers/test_default_request_handler.py
@@ -874,6 +874,7 @@ async def test_on_message_send_limit_history():
     assert task is not None
     assert task.history is not None and len(task.history) > 0
 
+
 @pytest.mark.asyncio
 async def test_on_message_send_limit_history_non_as_no_limit():
     task_store = InMemoryTaskStore()
@@ -893,7 +894,7 @@ async def test_on_message_send_limit_history_non_as_no_limit():
         configuration=MessageSendConfiguration(
             blocking=True,
             accepted_output_modes=['text/plain'],
-            history_length=None
+            history_length=None,
         ),
     )
 


### PR DESCRIPTION
Fixes a null pointer when message send configuration is provided with no history limit.