### PR TITLE
chore(ci): Update sort command to be case-insensitive

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -32,7 +32,7 @@ done
 SPELLING_ALLOW_FILE=".github/actions/spelling/allow.txt"
 if [ -f "$SPELLING_ALLOW_FILE" ]; then
     echo "Sorting and de-duplicating $SPELLING_ALLOW_FILE"
-    sort -u "$SPELLING_ALLOW_FILE" -o "$SPELLING_ALLOW_FILE"
+    sort -fu "$SPELLING_ALLOW_FILE" -o "$SPELLING_ALLOW_FILE"
 fi
 
 CHANGED_FILES=""


### PR DESCRIPTION
# Description
`allow.txt` is currently case insensitive. The formatting script does a case sensitive reformat introducing inconsistent formatting on running appropriate linting scripts. Addresses independent comment made: https://github.com/a2aproject/a2a-python/pull/522/files#r2538970891

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)
