### PR TITLE
fix: update A2A extension HTTP header

### DIFF
--- a/src/a2a/extensions/common.py
+++ b/src/a2a/extensions/common.py
@@ -3,7 +3,8 @@ from typing import Any
 from a2a.types import AgentCard, AgentExtension
 
 
-HTTP_EXTENSION_HEADER = 'X-A2A-Extensions'
+HTTP_EXTENSION_HEADER = 'A2A-Extensions'
+HTTP_EXTENSION_HEADER_DEPRECATED = 'X-A2A-Extensions'
 
 
 def get_requested_extensions(values: list[str]) -> set[str]:
@@ -33,7 +34,7 @@ def update_extension_header(
     http_kwargs: dict[str, Any] | None,
     extensions: list[str] | None,
 ) -> dict[str, Any]:
-    """Update the X-A2A-Extensions header with active extensions."""
+    """Update the A2A-Extensions header with active extensions."""
     http_kwargs = http_kwargs or {}
     if extensions is not None:
         headers = http_kwargs.setdefault('headers', {})

--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -137,11 +137,7 @@ class DefaultCallContextBuilder(CallContextBuilder):
             user = StarletteUserProxy(request.user)
             state['auth'] = request.auth
         state['headers'] = dict(request.headers)
-        extension_values = request.headers.getlist(HTTP_EXTENSION_HEADER)
-        if not extension_values:
-            extension_values = request.headers.getlist(
-                HTTP_EXTENSION_HEADER_DEPRECATED
-            )
+        extension_values = request.headers.getlist(HTTP_EXTENSION_HEADER) or request.headers.getlist(HTTP_EXTENSION_HEADER_DEPRECATED)
         return ServerCallContext(
             user=user,
             state=state,

--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -13,6 +13,7 @@ from a2a.auth.user import UnauthenticatedUser
 from a2a.auth.user import User as A2AUser
 from a2a.extensions.common import (
     HTTP_EXTENSION_HEADER,
+    HTTP_EXTENSION_HEADER_DEPRECATED,
     get_requested_extensions,
 )
 from a2a.server.context import ServerCallContext
@@ -136,12 +137,15 @@ class DefaultCallContextBuilder(CallContextBuilder):
             user = StarletteUserProxy(request.user)
             state['auth'] = request.auth
         state['headers'] = dict(request.headers)
+        extension_values = request.headers.getlist(HTTP_EXTENSION_HEADER)
+        if not extension_values:
+            extension_values = request.headers.getlist(
+                HTTP_EXTENSION_HEADER_DEPRECATED
+            )
         return ServerCallContext(
             user=user,
             state=state,
-            requested_extensions=get_requested_extensions(
-                request.headers.getlist(HTTP_EXTENSION_HEADER)
-            ),
+            requested_extensions=get_requested_extensions(extension_values),
         )
 
 

--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -137,7 +137,9 @@ class DefaultCallContextBuilder(CallContextBuilder):
             user = StarletteUserProxy(request.user)
             state['auth'] = request.auth
         state['headers'] = dict(request.headers)
-        extension_values = request.headers.getlist(HTTP_EXTENSION_HEADER) or request.headers.getlist(HTTP_EXTENSION_HEADER_DEPRECATED)
+        extension_values = request.headers.getlist(
+            HTTP_EXTENSION_HEADER
+        ) or request.headers.getlist(HTTP_EXTENSION_HEADER_DEPRECATED)
         return ServerCallContext(
             user=user,
             state=state,

--- a/src/a2a/server/request_handlers/grpc_handler.py
+++ b/src/a2a/server/request_handlers/grpc_handler.py
@@ -73,7 +73,9 @@ class DefaultCallContextBuilder(CallContextBuilder):
         state = {}
         with contextlib.suppress(Exception):
             state['grpc_context'] = context
-        extension_values = _get_metadata_value(context, HTTP_EXTENSION_HEADER) or _get_metadata_value(context, HTTP_EXTENSION_HEADER_DEPRECATED)
+        extension_values = _get_metadata_value(
+            context, HTTP_EXTENSION_HEADER
+        ) or _get_metadata_value(context, HTTP_EXTENSION_HEADER_DEPRECATED)
         return ServerCallContext(
             user=user,
             state=state,

--- a/src/a2a/server/request_handlers/grpc_handler.py
+++ b/src/a2a/server/request_handlers/grpc_handler.py
@@ -73,11 +73,7 @@ class DefaultCallContextBuilder(CallContextBuilder):
         state = {}
         with contextlib.suppress(Exception):
             state['grpc_context'] = context
-        extension_values = _get_metadata_value(context, HTTP_EXTENSION_HEADER)
-        if not extension_values:
-            extension_values = _get_metadata_value(
-                context, HTTP_EXTENSION_HEADER_DEPRECATED
-            )
+        extension_values = _get_metadata_value(context, HTTP_EXTENSION_HEADER) or _get_metadata_value(context, HTTP_EXTENSION_HEADER_DEPRECATED)
         return ServerCallContext(
             user=user,
             state=state,

--- a/src/a2a/server/request_handlers/grpc_handler.py
+++ b/src/a2a/server/request_handlers/grpc_handler.py
@@ -26,6 +26,7 @@ from a2a import types
 from a2a.auth.user import UnauthenticatedUser
 from a2a.extensions.common import (
     HTTP_EXTENSION_HEADER,
+    HTTP_EXTENSION_HEADER_DEPRECATED,
     get_requested_extensions,
 )
 from a2a.grpc import a2a_pb2
@@ -72,12 +73,15 @@ class DefaultCallContextBuilder(CallContextBuilder):
         state = {}
         with contextlib.suppress(Exception):
             state['grpc_context'] = context
+        extension_values = _get_metadata_value(context, HTTP_EXTENSION_HEADER)
+        if not extension_values:
+            extension_values = _get_metadata_value(
+                context, HTTP_EXTENSION_HEADER_DEPRECATED
+            )
         return ServerCallContext(
             user=user,
             state=state,
-            requested_extensions=get_requested_extensions(
-                _get_metadata_value(context, HTTP_EXTENSION_HEADER)
-            ),
+            requested_extensions=get_requested_extensions(extension_values),
         )
 
 

--- a/tests/client/transports/test_jsonrpc_client.py
+++ b/tests/client/transports/test_jsonrpc_client.py
@@ -847,7 +847,7 @@ class TestJsonRpcTransportExtensions:
         mock_httpx_client: AsyncMock,
         mock_agent_card: MagicMock,
     ):
-        """Test X-A2A-Extensions header in send_message_streaming."""
+        """Test A2A-Extensions header in send_message_streaming."""
         new_extensions = ['https://example.com/test-ext/v2']
         extensions = ['https://example.com/test-ext/v1']
         client = JsonRpcTransport(

--- a/tests/client/transports/test_rest_client.py
+++ b/tests/client/transports/test_rest_client.py
@@ -96,7 +96,7 @@ class TestRestTransportExtensions:
         mock_httpx_client: AsyncMock,
         mock_agent_card: MagicMock,
     ):
-        """Test X-A2A-Extensions header in send_message_streaming."""
+        """Test A2A-Extensions header in send_message_streaming."""
         new_extensions = ['https://example.com/test-ext/v2']
         extensions = ['https://example.com/test-ext/v1']
         client = RestTransport(

--- a/tests/integration/test_client_server_integration.py
+++ b/tests/integration/test_client_server_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from collections.abc import AsyncGenerator
 from typing import NamedTuple
 from unittest.mock import ANY, AsyncMock, patch
@@ -7,6 +8,7 @@ import grpc
 import httpx
 import pytest
 import pytest_asyncio
+
 from grpc.aio import Channel
 
 from a2a.client import ClientConfig
@@ -37,6 +39,7 @@ from a2a.types import (
     TextPart,
     TransportProtocol,
 )
+
 
 # --- Test Constants ---
 
@@ -819,9 +822,9 @@ async def test_base_client_sends_message_with_extensions(
         call_args, _ = mock_send_request.call_args
         kwargs = call_args[1]
         headers = kwargs.get('headers', {})
-        assert 'X-A2A-Extensions' in headers
+        assert 'A2A-Extensions' in headers
         assert (
-            headers['X-A2A-Extensions']
+            headers['A2A-Extensions']
             == 'https://example.com/test-ext/v1,https://example.com/test-ext/v2'
         )
 


### PR DESCRIPTION
# Description 

This PR updates the HTTP header name for extension support. It is currently defined as `X-A2A-Extensions`, however as of this recent commit that has changed:

- https://github.com/a2aproject/A2A/commit/c56ea72d5bb136944e52b40331d83ddedbce7c04
- https://github.com/a2aproject/A2A/pull/1248
- https://github.com/a2aproject/A2A/issues/1238

# Changes

The primary change comes from the `src/a2a/extensions/common.py` file:

```python
HTTP_EXTENSION_HEADER = 'A2A-Extensions'
HTTP_EXTENSION_HEADER_DEPRECATED = 'X-A2A-Extensions'
```

Minor functional changes were made in the JSON-RPC app:

```python
if not extension_values:
    extension_values = request.headers.getlist(
        HTTP_EXTENSION_HEADER_DEPRECATED
    )
```

# Additional Notes

There is also support for the deprecated `X-A2A-Extensions` header built-in as part of this PR. I'm happy to remove or enhance this support if necessary. 

---

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)
