### PR TITLE
test: adding tests for ID Generator and associated classes

### DIFF
--- a/tests/server/test_id_generator.py
+++ b/tests/server/test_id_generator.py
@@ -1,4 +1,5 @@
 """Tests for IDGenerator abstract base class."""
+
 import uuid
 
 from unittest.mock import patch
@@ -19,7 +20,9 @@ class TestIDGeneratorContext:
 
     def test_context_creation_with_all_fields(self):
         """Test creating context with all fields populated."""
-        context = IDGeneratorContext(task_id='task_123', context_id='context_456')
+        context = IDGeneratorContext(
+            task_id='task_123', context_id='context_456'
+        )
         assert context.task_id == 'task_123'
         assert context.context_id == 'context_456'
 
@@ -44,7 +47,7 @@ class TestIDGeneratorContext:
     def test_context_validation(self):
         """Test that context raises validation error for invalid types."""
         with pytest.raises(ValidationError):
-            IDGeneratorContext(task_id={"not": "a string"})  # noqa
+            IDGeneratorContext(task_id={'not': 'a string'})  # noqa
 
 
 class TestIDGenerator:
@@ -130,7 +133,9 @@ class TestUUIDGenerator:
     def test_generate_with_populated_context(self):
         """Test that generate works with a populated context."""
         generator = UUIDGenerator()
-        context = IDGeneratorContext(task_id='task_123', context_id='context_456')
+        context = IDGeneratorContext(
+            task_id='task_123', context_id='context_456'
+        )
         result = generator.generate(context)
         assert isinstance(result, str)
         uuid.UUID(result)


### PR DESCRIPTION
# Description

This PR adds tests for classes IDGenerator and related classes defined by `from a2a.server.id_generator import IDGeneratorContext, IDGenerator, UUIDGenerator`

Those tests pass 100%:

```
============================= test session starts ==============================
collecting ... collected 5 items

tests/server/test_id_generator.py::TestIDGeneratorContext::test_context_creation_with_all_fields PASSED [ 20%]
tests/server/test_id_generator.py::TestIDGeneratorContext::test_context_creation_with_defaults PASSED [ 40%]
tests/server/test_id_generator.py::TestIDGeneratorContext::test_context_creation_with_partial_fields PASSED [ 60%]
tests/server/test_id_generator.py::TestIDGeneratorContext::test_context_mutability PASSED [ 80%]
tests/server/test_id_generator.py::TestIDGeneratorContext::test_context_validation PASSED [100%]

============================== 5 passed in 0.05s ===============================

Process finished with exit code 0
```

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [N/A] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕

N/A
