### PR TITLE
fix: historyLength=0 returns full history (#573)

### DIFF
--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -83,9 +83,12 @@ def apply_history_length(task: Task, history_length: int | None) -> Task:
         A new task object with limited history
     """
     # Apply historyLength parameter if specified
-    if history_length is not None and history_length > 0 and task.history:
+    if history_length is not None and history_length >= 0:
         # Limit history to the most recent N messages
-        limited_history = task.history[-history_length:]
+        if task.history and history_length > 0:
+            limited_history = task.history[-history_length:]
+        else:
+            limited_history = []
         # Create a new task instance with limited history
         return task.model_copy(update={'history': limited_history})
 


### PR DESCRIPTION
This PR fixes a bug where setting historyLength=0 would return the full history instead of an empty list.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

Fixes #573  🦕
