### PR TITLE
ci: disable automatic PRs for spec updates

### DIFF
--- a/.github/workflows/update-a2a-types.yml
+++ b/.github/workflows/update-a2a-types.yml
@@ -1,8 +1,9 @@
 ---
 name: Update A2A Schema from Specification
 on:
-  repository_dispatch:
-    types: [a2a_json_update]
+#  TODO (https://github.com/a2aproject/a2a-python/issues/559): bring back once types are migrated, currently it generates many broken PRs
+#  repository_dispatch:
+#    types: [a2a_json_update]
   workflow_dispatch:
 jobs:
   generate_and_pr:


### PR DESCRIPTION
# Description

Currently it creates a lot of noise from broken PRs: https://github.com/a2aproject/a2a-python/pulls/a2a-bot.

While we're migrating to 1.0 spec we're not benefiting from this automation. `workflow_dispatch` (manual run) is still available.