### PR TITLE
ci: fix not committed uv.lock and use uv sync --locked

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --locked --dev
 
       - name: Run Ruff Linter
         id: ruff-lint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install dependencies
-        run: uv sync --dev --extra all
+        run: uv sync --locked --dev --extra all
       - name: Run tests and check coverage
         run: uv run pytest --cov=a2a --cov-report term --cov-fail-under=88
       - name: Show coverage summary in log

--- a/.github/workflows/update-a2a-types.yml
+++ b/.github/workflows/update-a2a-types.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure uv shell
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install dependencies (datamodel-code-generator)
-        run: uv sync
+        run: uv sync --locked
       - name: Define output file variable
         id: vars
         run: |

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ all = [
     { name = "grpcio-tools" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
+    { name = "pyjwt" },
     { name = "sqlalchemy", extra = ["aiomysql", "aiosqlite", "asyncio", "postgresql-asyncpg"] },
     { name = "sse-starlette" },
     { name = "starlette" },
@@ -49,6 +50,9 @@ mysql = [
 postgresql = [
     { name = "sqlalchemy", extra = ["asyncio", "postgresql-asyncpg"] },
 ]
+signing = [
+    { name = "pyjwt" },
+]
 sql = [
     { name = "sqlalchemy", extra = ["aiomysql", "aiosqlite", "asyncio", "postgresql-asyncpg"] },
 ]
@@ -68,6 +72,7 @@ dev = [
     { name = "mypy" },
     { name = "no-implicit-optional" },
     { name = "pre-commit" },
+    { name = "pyjwt" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -105,6 +110,8 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.33.0" },
     { name = "protobuf", specifier = ">=5.29.5" },
     { name = "pydantic", specifier = ">=2.11.3" },
+    { name = "pyjwt", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "pyjwt", marker = "extra == 'signing'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["aiomysql", "asyncio"], marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["aiomysql", "asyncio"], marker = "extra == 'mysql'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["aiomysql", "asyncio"], marker = "extra == 'sql'", specifier = ">=2.0.0" },
@@ -119,7 +126,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'all'" },
     { name = "starlette", marker = "extra == 'http-server'" },
 ]
-provides-extras = ["all", "encryption", "grpc", "http-server", "mysql", "postgresql", "sql", "sqlite", "telemetry"]
+provides-extras = ["all", "encryption", "grpc", "http-server", "mysql", "postgresql", "signing", "sql", "sqlite", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -129,6 +136,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "no-implicit-optional" },
     { name = "pre-commit" },
+    { name = "pyjwt", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
@@ -1532,6 +1540,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Doing `uv sync` now updates `uv.lock` with `pyjwt` added in #581. Commit updated file and update CI to fail on inconsistent `uv.lock` via `--locked`.

Tested via https://github.com/a2aproject/a2a-python/pull/637/changes/e6df935ad3185f1c203806cfb98aecfb92417825: [failed CI run](https://github.com/a2aproject/a2a-python/actions/runs/21206882696/job/61005414117?pr=637).
