### PR TITLE
ci: ignore URLs in spelling checks

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,0 +1,2 @@
+# Ignore URLs
+https?://\S+


### PR DESCRIPTION
# Description

Words from https://github.com/a2aproject/a2a-python/commit/2698cc04f15282fb358018f06bd88ae159d987b4 pushed to main branch directly used to fail #658.

Ignoring URLs according to the [docs](https://docs.check-spelling.dev/Configuration-Examples:-patterns).

The fix was tested in the affected PR: [before](https://github.com/a2aproject/a2a-python/actions/runs/21582994306), [after](https://github.com/a2aproject/a2a-python/actions/runs/21584577892).
