### PR TITLE
ci: use uv.lock for ruff version

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -27,15 +27,13 @@ jobs:
 
       - name: Run Ruff Linter
         id: ruff-lint
-        uses: astral-sh/ruff-action@v3
+        run: uv run ruff check --output-format=github
         continue-on-error: true
 
       - name: Run Ruff Formatter
         id: ruff-format
-        uses: astral-sh/ruff-action@v3
+        run: uv run ruff format --check
         continue-on-error: true
-        with:
-          args: "format --check"
 
       - name: Run MyPy Type Checker
         id: mypy


### PR DESCRIPTION
# Description

The GitHub action doesn't support using the exact version from `uv.lock` and uses `pyproject.toml` with version expression. As long as the version in tools cache satisfies this expression it's going to be used, however it has two problems:

1. Local runs can produce different results compared to CI.
2. CI results can change over time without code changes. Seems to be that it happened [here](https://github.com/a2aproject/a2a-python/pull/611#discussion_r2672007359) and also when trying to run linter on `1.0-dev`: [failure](https://github.com/a2aproject/a2a-python/actions/runs/21581854986).
