### PR TITLE
fix: suppress CancelledError in `_cleanup_producer`

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 
 from collections.abc import AsyncGenerator
@@ -435,7 +436,8 @@ class DefaultRequestHandler(RequestHandler):
         task_id: str,
     ) -> None:
         """Cleans up the agent execution task and queue manager entry."""
-        await producer_task
+        with contextlib.suppress(asyncio.CancelledError):
+            await producer_task
         await self._queue_manager.close(task_id)
         async with self._running_agents_lock:
             self._running_agents.pop(task_id, None)


### PR DESCRIPTION
# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)


### Problem

When a streaming response is interrupted by a client disconnect, the ASGI server cancels the response coroutine. The `on_message_send_stream` handler catches this and schedules `_cleanup_producer` as a background task to clean up resources. However, the `producer_task` itself may also have been cancelled by this point. When `_cleanup_producer` awaits the cancelled producer task, the `CancelledError` propagates out and the cleanup task fails, skipping `queue_manager.close()` and leaving a stale entry in `_running_agents`.

Here's a concrete scenario:

1. Client sends a request; the agent executes successfully (e.g. posts a Slack message)
2. The ASGI server tears down the connection scope, maybe because the reverse proxy enforced a response timeout, or the client hung up right as the response was being written
3. `on_message_send_stream` catches the `CancelledError`/`GeneratorExit` and schedules `_cleanup_producer` as a background task
4. `_cleanup_producer` does `await producer_task`, but the producer was also cancelled during teardown, so `CancelledError` propagates out
5. The queue and running-agents map are never cleaned up (resource leak)
6. If the framework surfaces the error to the HTTP layer, the client sees a `500`
7. The client retries the request, the agent runs again, and you get a duplicate Slack message

### Fix

Suppress `CancelledError` from `await producer_task` so that the subsequent resource cleanup (`queue_manager.close()` and `_running_agents` removal) always runs.

### Why this is safe

`await producer_task` in `_cleanup_producer` serves one purpose: waiting for the producer to finish before tearing down its resources. If the producer was cancelled, there are two cases:

- **The producer already finished:** The task completed and was then cancelled during teardown. The `CancelledError` is purely an artifact of lifecycle timing. Suppressing it is a no-op in practice.
- **The producer was still running:** Its work was interrupted and won't complete regardless. Suppressing the error just lets us clean up the queue and tracking state, which we need to do either way.

In both cases, the `CancelledError` carries no actionable information. The producer's actual result (if any) was already consumed by the `ResultAggregator` or `EventConsumer` upstream. `_cleanup_producer` never inspects the producer's return value; it only waits for completion so cleanup is ordered correctly. Suppressing the error preserves that ordering guarantee while making sure resources are always freed.


