### PR TITLE
chore: temporary freeze A2A repo ref in buf

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,7 +2,7 @@
 version: v2
 inputs:
   - git_repo: https://github.com/a2aproject/A2A.git
-    ref: main
+    ref: v1.0.0-rc
     subdir: specification
 managed:
   enabled: true


### PR DESCRIPTION
To resolve existing merge issues first.

TBD: It should be pinned to some tag either way or better `buf` invocation shouldn't happen during the build as proto changes do not happen that often and can be maintained manually
