### PR TITLE
build: prevent gen_proto.sh from hanging

### DIFF
--- a/scripts/gen_proto.sh
+++ b/scripts/gen_proto.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Run buf generate to regenerate protobuf code and OpenAPI spec
-npx @bufbuild/buf generate
+npx --yes @bufbuild/buf generate
 
 # The OpenAPI generator produces a file named like 'a2a.swagger.json' or similar.
 # We need it to be 'a2a.json' for the A2A SDK.


### PR DESCRIPTION
According to the [npx docs](https://docs.npmjs.com/cli/v8/commands/npx):

> If any requested packages are not present in the local project dependencies, then they are installed to a folder in the npm cache, which is added to the PATH environment variable in the executed process. A prompt is printed (which can be suppressed by providing either --yes or --no).

Running it in non-interactive manner hangs build process and waits for keyboard input.

See #706 for potential long-term solution.

Was originally added in #696.
