### PR TITLE
test: verify 400 for invalid historyLength in REST get_task

### DIFF
--- a/tests/server/apps/rest/test_rest_fastapi_app.py
+++ b/tests/server/apps/rest/test_rest_fastapi_app.py
@@ -559,5 +559,16 @@ class TestTenantExtraction:
         assert context.tenant == ''
 
 
+@pytest.mark.anyio
+async def test_get_task_invalid_history_length_returns_400(
+    client: AsyncClient,
+) -> None:
+    """Non-numeric historyLength query param returns 400 ParseError."""
+    response = await client.get('/tasks/some-task-id?historyLength=abc')
+    assert response.status_code == 400
+    data = response.json()
+    assert data.get('type') == 'ParseError'
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Replace unhandled int() conversion with Pydantic validation so non-numeric historyLength query params (e.g. ?historyLength=abc) return 422 InvalidParamsError instead of 500.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)