### PR TITLE
fix: add extra grpc header which is all lower case

### DIFF
--- a/src/a2a/extensions/common.py
+++ b/src/a2a/extensions/common.py
@@ -4,6 +4,7 @@ from a2a.types import AgentCard, AgentExtension
 
 
 HTTP_EXTENSION_HEADER = 'X-A2A-Extensions'
+GRPC_EXTENSION_HEADER = 'x-a2a-extensions'
 
 
 def get_requested_extensions(values: list[str]) -> set[str]:

--- a/src/a2a/server/request_handlers/grpc_handler.py
+++ b/src/a2a/server/request_handlers/grpc_handler.py
@@ -23,7 +23,7 @@ import a2a.grpc.a2a_pb2_grpc as a2a_grpc
 from a2a import types
 from a2a.auth.user import UnauthenticatedUser
 from a2a.extensions.common import (
-    HTTP_EXTENSION_HEADER,
+    GRPC_EXTENSION_HEADER,
     get_requested_extensions,
 )
 from a2a.grpc import a2a_pb2
@@ -76,7 +76,7 @@ class DefaultCallContextBuilder(CallContextBuilder):
             user=user,
             state=state,
             requested_extensions=get_requested_extensions(
-                _get_metadata_value(context, HTTP_EXTENSION_HEADER)
+                _get_metadata_value(context, GRPC_EXTENSION_HEADER)
             ),
         )
 
@@ -417,7 +417,7 @@ class GrpcHandler(a2a_grpc.A2AServiceServicer):
         if server_context.activated_extensions:
             context.set_trailing_metadata(
                 [
-                    (HTTP_EXTENSION_HEADER.lower(), e)
+                    (GRPC_EXTENSION_HEADER.lower(), e)
                     for e in sorted(server_context.activated_extensions)
                 ]
             )

--- a/tests/server/request_handlers/test_grpc_handler.py
+++ b/tests/server/request_handlers/test_grpc_handler.py
@@ -5,7 +5,7 @@ import grpc.aio
 import pytest
 
 from a2a import types
-from a2a.extensions.common import HTTP_EXTENSION_HEADER
+from a2a.extensions.common import GRPC_EXTENSION_HEADER
 from a2a.grpc import a2a_pb2
 from a2a.server.context import ServerCallContext
 from a2a.server.request_handlers import GrpcHandler, RequestHandler
@@ -350,8 +350,8 @@ class TestGrpcExtensions:
         mock_grpc_context: AsyncMock,
     ) -> None:
         mock_grpc_context.invocation_metadata.return_value = grpc.aio.Metadata(
-            (HTTP_EXTENSION_HEADER.lower(), 'foo'),
-            (HTTP_EXTENSION_HEADER.lower(), 'bar'),
+            (GRPC_EXTENSION_HEADER.lower(), 'foo'),
+            (GRPC_EXTENSION_HEADER.lower(), 'bar'),
         )
 
         def side_effect(request, context: ServerCallContext):
@@ -379,8 +379,8 @@ class TestGrpcExtensions:
             mock_grpc_context.set_trailing_metadata.call_args.args[0]
         )
         assert set(called_metadata) == {
-            (HTTP_EXTENSION_HEADER.lower(), 'foo'),
-            (HTTP_EXTENSION_HEADER.lower(), 'baz'),
+            (GRPC_EXTENSION_HEADER.lower(), 'foo'),
+            (GRPC_EXTENSION_HEADER.lower(), 'baz'),
         }
 
     async def test_send_message_with_comma_separated_extensions(
@@ -390,8 +390,8 @@ class TestGrpcExtensions:
         mock_grpc_context: AsyncMock,
     ) -> None:
         mock_grpc_context.invocation_metadata.return_value = grpc.aio.Metadata(
-            (HTTP_EXTENSION_HEADER.lower(), 'foo ,, bar,'),
-            (HTTP_EXTENSION_HEADER.lower(), 'baz  , bar'),
+            (GRPC_EXTENSION_HEADER.lower(), 'foo ,, bar,'),
+            (GRPC_EXTENSION_HEADER.lower(), 'baz  , bar'),
         )
         mock_request_handler.on_message_send.return_value = types.Message(
             message_id='1',
@@ -415,8 +415,8 @@ class TestGrpcExtensions:
         mock_grpc_context: AsyncMock,
     ) -> None:
         mock_grpc_context.invocation_metadata.return_value = grpc.aio.Metadata(
-            (HTTP_EXTENSION_HEADER.lower(), 'foo'),
-            (HTTP_EXTENSION_HEADER.lower(), 'bar'),
+            (GRPC_EXTENSION_HEADER.lower(), 'foo'),
+            (GRPC_EXTENSION_HEADER.lower(), 'bar'),
         )
 
         async def side_effect(request, context: ServerCallContext):
@@ -450,6 +450,6 @@ class TestGrpcExtensions:
             mock_grpc_context.set_trailing_metadata.call_args.args[0]
         )
         assert set(called_metadata) == {
-            (HTTP_EXTENSION_HEADER.lower(), 'foo'),
-            (HTTP_EXTENSION_HEADER.lower(), 'baz'),
+            (GRPC_EXTENSION_HEADER.lower(), 'foo'),
+            (GRPC_EXTENSION_HEADER.lower(), 'baz'),
         }


### PR DESCRIPTION
According to https://httpwg.org/specs/rfc7540.html#HttpHeaders headers in HTTP/2 (grpc transport) must all be lower case. Thus, using A2A via grpc fails when using the HTTP header. Add specific all lowercase header for gRPC.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)
