### PR TITLE
feat(compat): AgentCard backward compatibility helpers and tests

### DIFF
--- a/src/a2a/client/card_resolver.py
+++ b/src/a2a/client/card_resolver.py
@@ -6,9 +6,10 @@ from typing import Any
 
 import httpx
 
-from google.protobuf.json_format import ParseDict, ParseError
+from google.protobuf.json_format import ParseError
 
 from a2a.client.errors import AgentCardResolutionError
+from a2a.client.helpers import parse_agent_card
 from a2a.types.a2a_pb2 import (
     AgentCard,
 )
@@ -85,7 +86,7 @@ class A2ACardResolver:
                 target_url,
                 agent_card_data,
             )
-            agent_card = ParseDict(agent_card_data, AgentCard())
+            agent_card = parse_agent_card(agent_card_data)
             if signature_verifier:
                 signature_verifier(agent_card)
         except httpx.HTTPStatusError as e:

--- a/src/a2a/client/helpers.py
+++ b/src/a2a/client/helpers.py
@@ -1,8 +1,116 @@
 """Helper functions for the A2A client."""
 
+from typing import Any
 from uuid import uuid4
 
-from a2a.types.a2a_pb2 import Message, Part, Role
+from google.protobuf.json_format import ParseDict
+
+from a2a.types.a2a_pb2 import AgentCard, Message, Part, Role
+
+
+def parse_agent_card(agent_card_data: dict[str, Any]) -> AgentCard:
+    """Parse AgentCard JSON dictionary and handle backward compatibility."""
+    _handle_extended_card_compatibility(agent_card_data)
+    _handle_connection_fields_compatibility(agent_card_data)
+    _handle_security_compatibility(agent_card_data)
+
+    return ParseDict(agent_card_data, AgentCard(), ignore_unknown_fields=True)
+
+
+def _handle_extended_card_compatibility(
+    agent_card_data: dict[str, Any],
+) -> None:
+    """Map legacy supportsAuthenticatedExtendedCard to capabilities."""
+    if agent_card_data.pop('supportsAuthenticatedExtendedCard', None):
+        capabilities = agent_card_data.setdefault('capabilities', {})
+        if 'extendedAgentCard' not in capabilities:
+            capabilities['extendedAgentCard'] = True
+
+
+def _handle_connection_fields_compatibility(
+    agent_card_data: dict[str, Any],
+) -> None:
+    """Map legacy connection and transport fields to supportedInterfaces."""
+    main_url = agent_card_data.pop('url', None)
+    main_transport = agent_card_data.pop('preferredTransport', 'JSONRPC')
+    version = agent_card_data.pop('protocolVersion', '0.3.0')
+    additional_interfaces = (
+        agent_card_data.pop('additionalInterfaces', None) or []
+    )
+
+    if 'supportedInterfaces' not in agent_card_data and main_url:
+        supported_interfaces = []
+        supported_interfaces.append(
+            {
+                'url': main_url,
+                'protocolBinding': main_transport,
+                'protocolVersion': version,
+            }
+        )
+        supported_interfaces.extend(
+            {
+                'url': iface.get('url'),
+                'protocolBinding': iface.get('transport'),
+                'protocolVersion': version,
+            }
+            for iface in additional_interfaces
+        )
+        agent_card_data['supportedInterfaces'] = supported_interfaces
+
+
+def _map_legacy_security(
+    sec_list: list[dict[str, list[str]]],
+) -> list[dict[str, Any]]:
+    """Convert a legacy security requirement list into the 1.0.0 Protobuf format."""
+    return [
+        {
+            'schemes': {
+                scheme_name: {'list': scopes}
+                for scheme_name, scopes in sec_dict.items()
+            }
+        }
+        for sec_dict in sec_list
+    ]
+
+
+def _handle_security_compatibility(agent_card_data: dict[str, Any]) -> None:
+    """Map legacy security requirements and schemas to their 1.0.0 Protobuf equivalents."""
+    legacy_security = agent_card_data.pop('security', None)
+    if (
+        'securityRequirements' not in agent_card_data
+        and legacy_security is not None
+    ):
+        agent_card_data['securityRequirements'] = _map_legacy_security(
+            legacy_security
+        )
+
+    for skill in agent_card_data.get('skills', []):
+        legacy_skill_sec = skill.pop('security', None)
+        if 'securityRequirements' not in skill and legacy_skill_sec is not None:
+            skill['securityRequirements'] = _map_legacy_security(
+                legacy_skill_sec
+            )
+
+    security_schemes = agent_card_data.get('securitySchemes', {})
+    if security_schemes:
+        type_mapping = {
+            'apiKey': 'apiKeySecurityScheme',
+            'http': 'httpAuthSecurityScheme',
+            'oauth2': 'oauth2SecurityScheme',
+            'openIdConnect': 'openIdConnectSecurityScheme',
+            'mutualTLS': 'mtlsSecurityScheme',
+        }
+        for scheme in security_schemes.values():
+            scheme_type = scheme.pop('type', None)
+            if scheme_type in type_mapping:
+                # Map legacy 'in' to modern 'location'
+                if scheme_type == 'apiKey' and 'in' in scheme:
+                    scheme['location'] = scheme.pop('in')
+
+                mapped_name = type_mapping[scheme_type]
+                new_scheme_wrapper = {mapped_name: scheme.copy()}
+                scheme.clear()
+                scheme.update(new_scheme_wrapper)
 
 
 def create_text_message_object(

--- a/src/a2a/client/transports/jsonrpc.py
+++ b/src/a2a/client/transports/jsonrpc.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import httpx
 
 from google.protobuf import json_format
+from google.protobuf.json_format import ParseDict
 from jsonrpc.jsonrpc2 import JSONRPC20Request, JSONRPC20Response
 
 from a2a.client.errors import A2AClientError
@@ -413,8 +414,13 @@ class JsonRpcTransport(ClientTransport):
         json_rpc_response = JSONRPC20Response(**response_data)
         if json_rpc_response.error:
             raise self._create_jsonrpc_error(json_rpc_response.error)
-        response: AgentCard = json_format.ParseDict(
-            json_rpc_response.result, AgentCard()
+        # Validate type of the response
+        if not isinstance(json_rpc_response.result, dict):
+            raise A2AClientError(
+                f'Invalid response type: {type(json_rpc_response.result)}'
+            )
+        response: AgentCard = ParseDict(
+            cast('dict[str, Any]', json_rpc_response.result), AgentCard()
         )
         if signature_verifier:
             signature_verifier(response)

--- a/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
+++ b/src/a2a/server/apps/jsonrpc/jsonrpc_app.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-from google.protobuf.json_format import MessageToDict, ParseDict
+from google.protobuf.json_format import ParseDict
 from jsonrpc.jsonrpc2 import JSONRPC20Request
 
 from a2a.auth.user import UnauthenticatedUser
@@ -29,7 +29,10 @@ from a2a.server.jsonrpc_models import (
 )
 from a2a.server.request_handlers.jsonrpc_handler import JSONRPCHandler
 from a2a.server.request_handlers.request_handler import RequestHandler
-from a2a.server.request_handlers.response_helpers import build_error_response
+from a2a.server.request_handlers.response_helpers import (
+    agent_card_to_dict,
+    build_error_response,
+)
 from a2a.types import A2ARequest
 from a2a.types.a2a_pb2 import (
     AgentCard,
@@ -575,9 +578,8 @@ class JSONRPCApplication(ABC):
             card_to_serve = await maybe_await(self.card_modifier(card_to_serve))
 
         return JSONResponse(
-            MessageToDict(
+            agent_card_to_dict(
                 card_to_serve,
-                preserving_proto_field_name=False,
             )
         )
 

--- a/src/a2a/server/request_handlers/response_helpers.py
+++ b/src/a2a/server/request_handlers/response_helpers.py
@@ -6,6 +6,7 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import Message as ProtoMessage
 from jsonrpc.jsonrpc2 import JSONRPC20Response
 
+from a2a.compat.v0_3.conversions import to_compat_agent_card
 from a2a.server.jsonrpc_models import (
     InternalError as JSONRPCInternalError,
 )
@@ -13,6 +14,7 @@ from a2a.server.jsonrpc_models import (
     JSONRPCError,
 )
 from a2a.types.a2a_pb2 import (
+    AgentCard,
     ListTasksResponse,
     Message,
     StreamResponse,
@@ -87,6 +89,32 @@ EventTypes = (
     | ListTasksResponse
 )
 """Type alias for possible event types produced by handlers."""
+
+
+def agent_card_to_dict(card: AgentCard) -> dict[str, Any]:
+    """Convert AgentCard to dict and inject backward compatibility fields."""
+    result = MessageToDict(card)
+
+    compat_card = to_compat_agent_card(card)
+    compat_dict = compat_card.model_dump(exclude_none=True)
+
+    # Do not include supportsAuthenticatedExtendedCard if false
+    if not compat_dict.get('supportsAuthenticatedExtendedCard'):
+        compat_dict.pop('supportsAuthenticatedExtendedCard', None)
+
+    def merge(dict1: dict[str, Any], dict2: dict[str, Any]) -> dict[str, Any]:
+        for k, v in dict2.items():
+            if k not in dict1:
+                dict1[k] = v
+            elif isinstance(v, dict) and isinstance(dict1[k], dict):
+                merge(dict1[k], v)
+            elif isinstance(v, list) and isinstance(dict1[k], list):
+                for i in range(min(len(dict1[k]), len(v))):
+                    if isinstance(dict1[k][i], dict) and isinstance(v[i], dict):
+                        merge(dict1[k][i], v[i])
+        return dict1
+
+    return merge(result, compat_dict)
 
 
 def build_error_response(

--- a/tests/client/test_card_resolver.py
+++ b/tests/client/test_card_resolver.py
@@ -260,7 +260,7 @@ class TestGetAgentCard:
         valid_agent_card_data,
     ):
         """Test A2AClientJSONError is raised on agent card validation error."""
-        return_json = {'invalid': 'data'}
+        return_json = {'name': {'invalid': 'type'}}
         mock_response.json.return_value = return_json
         mock_httpx_client.get.return_value = mock_response
         with pytest.raises(AgentCardResolutionError) as exc_info:

--- a/tests/client/test_client_helpers.py
+++ b/tests/client/test_client_helpers.py
@@ -1,0 +1,695 @@
+import copy
+import difflib
+import json
+from google.protobuf.json_format import MessageToDict
+
+from a2a.client.helpers import create_text_message_object, parse_agent_card
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
+from a2a.types.a2a_pb2 import (
+    APIKeySecurityScheme,
+    AgentCapabilities,
+    AgentCard,
+    AgentCardSignature,
+    AgentInterface,
+    AgentProvider,
+    AgentSkill,
+    AuthorizationCodeOAuthFlow,
+    HTTPAuthSecurityScheme,
+    MutualTlsSecurityScheme,
+    OAuth2SecurityScheme,
+    OAuthFlows,
+    OpenIdConnectSecurityScheme,
+    Role,
+    SecurityRequirement,
+    SecurityScheme,
+    StringList,
+)
+
+
+def test_parse_agent_card_legacy_support() -> None:
+    data = {
+        'name': 'Legacy Agent',
+        'description': 'Legacy Description',
+        'version': '1.0',
+        'supportsAuthenticatedExtendedCard': True,
+    }
+    card = parse_agent_card(data)
+    assert card.name == 'Legacy Agent'
+    assert card.capabilities.extended_agent_card is True
+    # Ensure it's popped from the dict
+    assert 'supportsAuthenticatedExtendedCard' not in data
+
+
+def test_parse_agent_card_new_support() -> None:
+    data = {
+        'name': 'New Agent',
+        'description': 'New Description',
+        'version': '1.0',
+        'capabilities': {'extendedAgentCard': True},
+    }
+    card = parse_agent_card(data)
+    assert card.name == 'New Agent'
+    assert card.capabilities.extended_agent_card is True
+
+
+def test_parse_agent_card_no_support() -> None:
+    data = {
+        'name': 'No Support Agent',
+        'description': 'No Support Description',
+        'version': '1.0',
+        'capabilities': {'extendedAgentCard': False},
+    }
+    card = parse_agent_card(data)
+    assert card.name == 'No Support Agent'
+    assert card.capabilities.extended_agent_card is False
+
+
+def test_parse_agent_card_both_legacy_and_new() -> None:
+    data = {
+        'name': 'Mixed Agent',
+        'description': 'Mixed Description',
+        'version': '1.0',
+        'supportsAuthenticatedExtendedCard': True,
+        'capabilities': {'streaming': True},
+    }
+    card = parse_agent_card(data)
+    assert card.name == 'Mixed Agent'
+    assert card.capabilities.streaming is True
+    assert card.capabilities.extended_agent_card is True
+
+
+def _assert_agent_card_diff(original_data: dict, serialized_data: dict) -> None:
+    """Helper to assert that the re-serialized 1.0.0 JSON payload contains all original 0.3.0 data (no dropped fields)."""
+    original_json_str = json.dumps(original_data, indent=2, sort_keys=True)
+    serialized_json_str = json.dumps(serialized_data, indent=2, sort_keys=True)
+
+    diff_lines = list(
+        difflib.unified_diff(
+            original_json_str.splitlines(),
+            serialized_json_str.splitlines(),
+            lineterm='',
+        )
+    )
+
+    removed_lines = []
+    for line in diff_lines:
+        if line.startswith('-') and not line.startswith('---'):
+            removed_lines.append(line)
+
+    if removed_lines:
+        error_msg = (
+            'Re-serialization dropped fields from the original payload:\n'
+            + '\n'.join(removed_lines)
+        )
+        raise AssertionError(error_msg)
+
+
+def test_parse_typical_030_agent_card() -> None:
+    data = {
+        'additionalInterfaces': [
+            {'transport': 'GRPC', 'url': 'http://agent.example.com/api/grpc'}
+        ],
+        'capabilities': {'streaming': True},
+        'defaultInputModes': ['text/plain'],
+        'defaultOutputModes': ['application/json'],
+        'description': 'A typical agent from 0.3.0',
+        'name': 'Typical Agent 0.3',
+        'preferredTransport': 'JSONRPC',
+        'protocolVersion': '0.3.0',
+        'security': [{'test_oauth': ['read', 'write']}],
+        'securitySchemes': {
+            'test_oauth': {
+                'description': 'OAuth2 authentication',
+                'flows': {
+                    'authorizationCode': {
+                        'authorizationUrl': 'http://auth.example.com',
+                        'scopes': {
+                            'read': 'Read access',
+                            'write': 'Write access',
+                        },
+                        'tokenUrl': 'http://token.example.com',
+                    }
+                },
+                'type': 'oauth2',
+            }
+        },
+        'skills': [
+            {
+                'description': 'The first skill',
+                'id': 'skill-1',
+                'name': 'Skill 1',
+                'security': [{'test_oauth': ['read']}],
+                'tags': ['example'],
+            }
+        ],
+        'supportsAuthenticatedExtendedCard': True,
+        'url': 'http://agent.example.com/api',
+        'version': '1.0',
+    }
+    original_data = copy.deepcopy(data)
+    card = parse_agent_card(data)
+
+    expected_card = AgentCard(
+        name='Typical Agent 0.3',
+        description='A typical agent from 0.3.0',
+        version='1.0',
+        capabilities=AgentCapabilities(
+            extended_agent_card=True, streaming=True
+        ),
+        default_input_modes=['text/plain'],
+        default_output_modes=['application/json'],
+        supported_interfaces=[
+            AgentInterface(
+                url='http://agent.example.com/api',
+                protocol_binding='JSONRPC',
+                protocol_version='0.3.0',
+            ),
+            AgentInterface(
+                url='http://agent.example.com/api/grpc',
+                protocol_binding='GRPC',
+                protocol_version='0.3.0',
+            ),
+        ],
+        security_requirements=[
+            SecurityRequirement(
+                schemes={'test_oauth': StringList(list=['read', 'write'])}
+            )
+        ],
+        security_schemes={
+            'test_oauth': SecurityScheme(
+                oauth2_security_scheme=OAuth2SecurityScheme(
+                    description='OAuth2 authentication',
+                    flows=OAuthFlows(
+                        authorization_code=AuthorizationCodeOAuthFlow(
+                            authorization_url='http://auth.example.com',
+                            token_url='http://token.example.com',
+                            scopes={
+                                'read': 'Read access',
+                                'write': 'Write access',
+                            },
+                        )
+                    ),
+                )
+            )
+        },
+        skills=[
+            AgentSkill(
+                id='skill-1',
+                name='Skill 1',
+                description='The first skill',
+                tags=['example'],
+                security_requirements=[
+                    SecurityRequirement(
+                        schemes={'test_oauth': StringList(list=['read'])}
+                    )
+                ],
+            )
+        ],
+    )
+
+    assert card == expected_card
+
+    # Serialize back to JSON and compare
+    serialized_data = agent_card_to_dict(card)
+
+    _assert_agent_card_diff(original_data, serialized_data)
+    assert 'preferredTransport' in serialized_data
+
+    # Re-parse from the serialized payload and verify identical to original parsing
+    re_parsed_card = parse_agent_card(copy.deepcopy(serialized_data))
+    assert re_parsed_card == card
+
+
+def test_parse_agent_card_security_scheme_without_in() -> None:
+    data = {
+        'name': 'API Key Agent',
+        'description': 'API Key without in param',
+        'version': '1.0',
+        'securitySchemes': {
+            'test_api_key': {'type': 'apiKey', 'name': 'X-API-KEY'}
+        },
+    }
+    card = parse_agent_card(data)
+    assert 'test_api_key' in card.security_schemes
+    assert (
+        card.security_schemes['test_api_key'].api_key_security_scheme.name
+        == 'X-API-KEY'
+    )
+    assert (
+        card.security_schemes['test_api_key'].api_key_security_scheme.location
+        == ''
+    )
+
+
+def test_parse_agent_card_security_scheme_unknown_type() -> None:
+    data = {
+        'name': 'Unknown Scheme Agent',
+        'description': 'Has unknown scheme type',
+        'version': '1.0',
+        'securitySchemes': {
+            'test_unknown': {'type': 'someFutureType', 'future_prop': 'value'},
+            'test_missing_type': {'prop': 'value'},
+        },
+    }
+    card = parse_agent_card(data)
+    # the ParseDict ignore_unknown_fields=True handles the unknown fields.
+    # Because there is no mapping logic for 'someFutureType', the Protobuf
+    # creates an empty SecurityScheme message under those keys.
+    assert 'test_unknown' in card.security_schemes
+    assert not card.security_schemes['test_unknown'].WhichOneof('scheme')
+
+    assert 'test_missing_type' in card.security_schemes
+    assert not card.security_schemes['test_missing_type'].WhichOneof('scheme')
+
+
+def test_create_text_message_object() -> None:
+    msg = create_text_message_object(role=Role.ROLE_AGENT, content='Hello')
+    assert msg.role == Role.ROLE_AGENT
+    assert len(msg.parts) == 1
+    assert msg.parts[0].text == 'Hello'
+    assert msg.message_id != ''
+
+
+def test_parse_030_agent_card_route_planner() -> None:
+    data = {
+        'protocolVersion': '0.3',
+        'name': 'GeoSpatial Route Planner Agent',
+        'description': 'Provides advanced route planning.',
+        'url': 'https://georoute-agent.example.com/a2a/v1',
+        'preferredTransport': 'JSONRPC',
+        'additionalInterfaces': [
+            {
+                'url': 'https://georoute-agent.example.com/a2a/v1',
+                'transport': 'JSONRPC',
+            },
+            {
+                'url': 'https://georoute-agent.example.com/a2a/grpc',
+                'transport': 'GRPC',
+            },
+            {
+                'url': 'https://georoute-agent.example.com/a2a/json',
+                'transport': 'HTTP+JSON',
+            },
+        ],
+        'provider': {
+            'organization': 'Example Geo Services Inc.',
+            'url': 'https://www.examplegeoservices.com',
+        },
+        'iconUrl': 'https://georoute-agent.example.com/icon.png',
+        'version': '1.2.0',
+        'documentationUrl': 'https://docs.examplegeoservices.com/georoute-agent/api',
+        'supportsAuthenticatedExtendedCard': True,
+        'capabilities': {
+            'streaming': True,
+            'pushNotifications': True,
+            'stateTransitionHistory': False,
+        },
+        'securitySchemes': {
+            'google': {
+                'type': 'openIdConnect',
+                'openIdConnectUrl': 'https://accounts.google.com/.well-known/openid-configuration',
+            }
+        },
+        'security': [{'google': ['openid', 'profile', 'email']}],
+        'defaultInputModes': ['application/json', 'text/plain'],
+        'defaultOutputModes': ['application/json', 'image/png'],
+        'skills': [
+            {
+                'id': 'route-optimizer-traffic',
+                'name': 'Traffic-Aware Route Optimizer',
+                'description': 'Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).',
+                'tags': [
+                    'maps',
+                    'routing',
+                    'navigation',
+                    'directions',
+                    'traffic',
+                ],
+                'examples': [
+                    "Plan a route from '1600 Amphitheatre Parkway, Mountain View, CA' to 'San Francisco International Airport' avoiding tolls.",
+                    '{"origin": {"lat": 37.422, "lng": -122.084}, "destination": {"lat": 37.7749, "lng": -122.4194}, "preferences": ["avoid_ferries"]}',
+                ],
+                'inputModes': ['application/json', 'text/plain'],
+                'outputModes': [
+                    'application/json',
+                    'application/vnd.geo+json',
+                    'text/html',
+                ],
+                'security': [
+                    {'example': []},
+                    {'google': ['openid', 'profile', 'email']},
+                ],
+            },
+            {
+                'id': 'custom-map-generator',
+                'name': 'Personalized Map Generator',
+                'description': 'Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.',
+                'tags': [
+                    'maps',
+                    'customization',
+                    'visualization',
+                    'cartography',
+                ],
+                'examples': [
+                    'Generate a map of my upcoming road trip with all planned stops highlighted.',
+                    'Show me a map visualizing all coffee shops within a 1-mile radius of my current location.',
+                ],
+                'inputModes': ['application/json'],
+                'outputModes': [
+                    'image/png',
+                    'image/jpeg',
+                    'application/json',
+                    'text/html',
+                ],
+            },
+        ],
+        'signatures': [
+            {
+                'protected': 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0',
+                'signature': 'QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ',
+            }
+        ],
+    }
+
+    original_data = copy.deepcopy(data)
+    card = parse_agent_card(data)
+
+    expected_card = AgentCard(
+        name='GeoSpatial Route Planner Agent',
+        description='Provides advanced route planning.',
+        version='1.2.0',
+        documentation_url='https://docs.examplegeoservices.com/georoute-agent/api',
+        icon_url='https://georoute-agent.example.com/icon.png',
+        provider=AgentProvider(
+            organization='Example Geo Services Inc.',
+            url='https://www.examplegeoservices.com',
+        ),
+        capabilities=AgentCapabilities(
+            extended_agent_card=True, streaming=True, push_notifications=True
+        ),
+        default_input_modes=['application/json', 'text/plain'],
+        default_output_modes=['application/json', 'image/png'],
+        supported_interfaces=[
+            AgentInterface(
+                url='https://georoute-agent.example.com/a2a/v1',
+                protocol_binding='JSONRPC',
+                protocol_version='0.3',
+            ),
+            AgentInterface(
+                url='https://georoute-agent.example.com/a2a/v1',
+                protocol_binding='JSONRPC',
+                protocol_version='0.3',
+            ),
+            AgentInterface(
+                url='https://georoute-agent.example.com/a2a/grpc',
+                protocol_binding='GRPC',
+                protocol_version='0.3',
+            ),
+            AgentInterface(
+                url='https://georoute-agent.example.com/a2a/json',
+                protocol_binding='HTTP+JSON',
+                protocol_version='0.3',
+            ),
+        ],
+        security_requirements=[
+            SecurityRequirement(
+                schemes={
+                    'google': StringList(list=['openid', 'profile', 'email'])
+                }
+            )
+        ],
+        security_schemes={
+            'google': SecurityScheme(
+                open_id_connect_security_scheme=OpenIdConnectSecurityScheme(
+                    open_id_connect_url='https://accounts.google.com/.well-known/openid-configuration'
+                )
+            )
+        },
+        skills=[
+            AgentSkill(
+                id='route-optimizer-traffic',
+                name='Traffic-Aware Route Optimizer',
+                description='Calculates the optimal driving route between two or more locations, taking into account real-time traffic conditions, road closures, and user preferences (e.g., avoid tolls, prefer highways).',
+                tags=['maps', 'routing', 'navigation', 'directions', 'traffic'],
+                examples=[
+                    "Plan a route from '1600 Amphitheatre Parkway, Mountain View, CA' to 'San Francisco International Airport' avoiding tolls.",
+                    '{"origin": {"lat": 37.422, "lng": -122.084}, "destination": {"lat": 37.7749, "lng": -122.4194}, "preferences": ["avoid_ferries"]}',
+                ],
+                input_modes=['application/json', 'text/plain'],
+                output_modes=[
+                    'application/json',
+                    'application/vnd.geo+json',
+                    'text/html',
+                ],
+                security_requirements=[
+                    SecurityRequirement(schemes={'example': StringList()}),
+                    SecurityRequirement(
+                        schemes={
+                            'google': StringList(
+                                list=['openid', 'profile', 'email']
+                            )
+                        }
+                    ),
+                ],
+            ),
+            AgentSkill(
+                id='custom-map-generator',
+                name='Personalized Map Generator',
+                description='Creates custom map images or interactive map views based on user-defined points of interest, routes, and style preferences. Can overlay data layers.',
+                tags=['maps', 'customization', 'visualization', 'cartography'],
+                examples=[
+                    'Generate a map of my upcoming road trip with all planned stops highlighted.',
+                    'Show me a map visualizing all coffee shops within a 1-mile radius of my current location.',
+                ],
+                input_modes=['application/json'],
+                output_modes=[
+                    'image/png',
+                    'image/jpeg',
+                    'application/json',
+                    'text/html',
+                ],
+            ),
+        ],
+        signatures=[
+            AgentCardSignature(
+                protected='eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSIsImprdSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYWdlbnQvandrcy5qc29uIn0',
+                signature='QFdkNLNszlGj3z3u0YQGt_T9LixY3qtdQpZmsTdDHDe3fXV9y9-B3m2-XgCpzuhiLt8E0tV6HXoZKHv4GtHgKQ',
+            )
+        ],
+    )
+
+    assert card == expected_card
+
+    # Serialize back to JSON and compare
+    serialized_data = agent_card_to_dict(card)
+
+    # Remove deprecated stateTransitionHistory before diffing
+    del original_data['capabilities']['stateTransitionHistory']
+
+    _assert_agent_card_diff(original_data, serialized_data)
+
+    # Re-parse from the serialized payload and verify identical to original parsing
+    re_parsed_card = parse_agent_card(copy.deepcopy(serialized_data))
+    assert re_parsed_card == card
+
+
+def test_parse_complex_030_agent_card() -> None:
+    data = {
+        'additionalInterfaces': [
+            {
+                'transport': 'GRPC',
+                'url': 'http://complex.agent.example.com/grpc',
+            },
+            {
+                'transport': 'JSONRPC',
+                'url': 'http://complex.agent.example.com/jsonrpc',
+            },
+        ],
+        'capabilities': {'pushNotifications': True, 'streaming': True},
+        'defaultInputModes': ['text/plain', 'application/json'],
+        'defaultOutputModes': ['application/json', 'image/png'],
+        'description': 'A very complex agent from 0.3.0',
+        'name': 'Complex Agent 0.3',
+        'preferredTransport': 'HTTP+JSON',
+        'protocolVersion': '0.3.0',
+        'security': [
+            {'test_oauth': ['read', 'write'], 'test_api_key': []},
+            {'test_http': []},
+            {'test_oidc': ['openid', 'profile']},
+            {'test_mtls': []},
+        ],
+        'securitySchemes': {
+            'test_oauth': {
+                'description': 'OAuth2 authentication',
+                'flows': {
+                    'authorizationCode': {
+                        'authorizationUrl': 'http://auth.example.com',
+                        'scopes': {
+                            'read': 'Read access',
+                            'write': 'Write access',
+                        },
+                        'tokenUrl': 'http://token.example.com',
+                    }
+                },
+                'type': 'oauth2',
+            },
+            'test_api_key': {
+                'description': 'API Key auth',
+                'in': 'header',
+                'name': 'X-API-KEY',
+                'type': 'apiKey',
+            },
+            'test_http': {
+                'bearerFormat': 'JWT',
+                'description': 'HTTP Basic auth',
+                'scheme': 'basic',
+                'type': 'http',
+            },
+            'test_oidc': {
+                'description': 'OIDC Auth',
+                'openIdConnectUrl': 'https://example.com/.well-known/openid-configuration',
+                'type': 'openIdConnect',
+            },
+            'test_mtls': {'description': 'mTLS Auth', 'type': 'mutualTLS'},
+        },
+        'skills': [
+            {
+                'description': 'The first complex skill',
+                'id': 'skill-1',
+                'inputModes': ['application/json'],
+                'name': 'Complex Skill 1',
+                'outputModes': ['application/json'],
+                'security': [{'test_api_key': []}],
+                'tags': ['example', 'complex'],
+            },
+            {
+                'description': 'The second complex skill',
+                'id': 'skill-2',
+                'name': 'Complex Skill 2',
+                'security': [{'test_oidc': ['openid']}],
+                'tags': ['example2'],
+            },
+        ],
+        'supportsAuthenticatedExtendedCard': True,
+        'url': 'http://complex.agent.example.com/api',
+        'version': '1.5.2',
+    }
+    original_data = copy.deepcopy(data)
+    card = parse_agent_card(data)
+
+    expected_card = AgentCard(
+        name='Complex Agent 0.3',
+        description='A very complex agent from 0.3.0',
+        version='1.5.2',
+        capabilities=AgentCapabilities(
+            extended_agent_card=True, streaming=True, push_notifications=True
+        ),
+        default_input_modes=['text/plain', 'application/json'],
+        default_output_modes=['application/json', 'image/png'],
+        supported_interfaces=[
+            AgentInterface(
+                url='http://complex.agent.example.com/api',
+                protocol_binding='HTTP+JSON',
+                protocol_version='0.3.0',
+            ),
+            AgentInterface(
+                url='http://complex.agent.example.com/grpc',
+                protocol_binding='GRPC',
+                protocol_version='0.3.0',
+            ),
+            AgentInterface(
+                url='http://complex.agent.example.com/jsonrpc',
+                protocol_binding='JSONRPC',
+                protocol_version='0.3.0',
+            ),
+        ],
+        security_requirements=[
+            SecurityRequirement(
+                schemes={
+                    'test_oauth': StringList(list=['read', 'write']),
+                    'test_api_key': StringList(),
+                }
+            ),
+            SecurityRequirement(schemes={'test_http': StringList()}),
+            SecurityRequirement(
+                schemes={'test_oidc': StringList(list=['openid', 'profile'])}
+            ),
+            SecurityRequirement(schemes={'test_mtls': StringList()}),
+        ],
+        security_schemes={
+            'test_oauth': SecurityScheme(
+                oauth2_security_scheme=OAuth2SecurityScheme(
+                    description='OAuth2 authentication',
+                    flows=OAuthFlows(
+                        authorization_code=AuthorizationCodeOAuthFlow(
+                            authorization_url='http://auth.example.com',
+                            token_url='http://token.example.com',
+                            scopes={
+                                'read': 'Read access',
+                                'write': 'Write access',
+                            },
+                        )
+                    ),
+                )
+            ),
+            'test_api_key': SecurityScheme(
+                api_key_security_scheme=APIKeySecurityScheme(
+                    description='API Key auth',
+                    location='header',
+                    name='X-API-KEY',
+                )
+            ),
+            'test_http': SecurityScheme(
+                http_auth_security_scheme=HTTPAuthSecurityScheme(
+                    description='HTTP Basic auth',
+                    scheme='basic',
+                    bearer_format='JWT',
+                )
+            ),
+            'test_oidc': SecurityScheme(
+                open_id_connect_security_scheme=OpenIdConnectSecurityScheme(
+                    description='OIDC Auth',
+                    open_id_connect_url='https://example.com/.well-known/openid-configuration',
+                )
+            ),
+            'test_mtls': SecurityScheme(
+                mtls_security_scheme=MutualTlsSecurityScheme(
+                    description='mTLS Auth'
+                )
+            ),
+        },
+        skills=[
+            AgentSkill(
+                id='skill-1',
+                name='Complex Skill 1',
+                description='The first complex skill',
+                tags=['example', 'complex'],
+                input_modes=['application/json'],
+                output_modes=['application/json'],
+                security_requirements=[
+                    SecurityRequirement(schemes={'test_api_key': StringList()})
+                ],
+            ),
+            AgentSkill(
+                id='skill-2',
+                name='Complex Skill 2',
+                description='The second complex skill',
+                tags=['example2'],
+                security_requirements=[
+                    SecurityRequirement(
+                        schemes={'test_oidc': StringList(list=['openid'])}
+                    )
+                ],
+            ),
+        ],
+    )
+
+    assert card == expected_card
+
+    # Serialize back to JSON and compare
+    serialized_data = agent_card_to_dict(card)
+    _assert_agent_card_diff(original_data, serialized_data)
+
+    # Re-parse from the serialized payload and verify identical to original parsing
+    re_parsed_card = parse_agent_card(copy.deepcopy(serialized_data))
+    assert re_parsed_card == card

--- a/tests/integration/cross_version/test_cross_version_card_validation.py
+++ b/tests/integration/cross_version/test_cross_version_card_validation.py
@@ -1,0 +1,199 @@
+import json
+import subprocess
+
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
+from a2a.types.a2a_pb2 import (
+    APIKeySecurityScheme,
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    AuthorizationCodeOAuthFlow,
+    HTTPAuthSecurityScheme,
+    MutualTlsSecurityScheme,
+    OAuth2SecurityScheme,
+    OAuthFlows,
+    OpenIdConnectSecurityScheme,
+    SecurityRequirement,
+    SecurityScheme,
+    StringList,
+)
+from a2a.client.helpers import parse_agent_card
+from google.protobuf.json_format import MessageToDict, ParseDict
+
+
+def test_cross_version_agent_card_deserialization() -> None:
+    # 1. Complex card
+    complex_card = AgentCard(
+        name='Complex Agent 0.3',
+        description='A very complex agent from 0.3.0',
+        version='1.5.2',
+        capabilities=AgentCapabilities(
+            extended_agent_card=True, streaming=True, push_notifications=True
+        ),
+        default_input_modes=['text/plain', 'application/json'],
+        default_output_modes=['application/json', 'image/png'],
+        supported_interfaces=[
+            AgentInterface(
+                url='http://complex.agent.example.com/api',
+                protocol_binding='HTTP+JSON',
+                protocol_version='0.3.0',
+            ),
+            AgentInterface(
+                url='http://complex.agent.example.com/grpc',
+                protocol_binding='GRPC',
+                protocol_version='0.3.0',
+            ),
+            AgentInterface(
+                url='http://complex.agent.example.com/jsonrpc',
+                protocol_binding='JSONRPC',
+                protocol_version='0.3.0',
+            ),
+        ],
+        security_requirements=[
+            SecurityRequirement(
+                schemes={
+                    'test_oauth': StringList(list=['read', 'write']),
+                    'test_api_key': StringList(),
+                }
+            ),
+            SecurityRequirement(schemes={'test_http': StringList()}),
+            SecurityRequirement(
+                schemes={'test_oidc': StringList(list=['openid', 'profile'])}
+            ),
+            SecurityRequirement(schemes={'test_mtls': StringList()}),
+        ],
+        security_schemes={
+            'test_oauth': SecurityScheme(
+                oauth2_security_scheme=OAuth2SecurityScheme(
+                    description='OAuth2 authentication',
+                    flows=OAuthFlows(
+                        authorization_code=AuthorizationCodeOAuthFlow(
+                            authorization_url='http://auth.example.com',
+                            token_url='http://token.example.com',
+                            scopes={
+                                'read': 'Read access',
+                                'write': 'Write access',
+                            },
+                        )
+                    ),
+                )
+            ),
+            'test_api_key': SecurityScheme(
+                api_key_security_scheme=APIKeySecurityScheme(
+                    description='API Key auth',
+                    location='header',
+                    name='X-API-KEY',
+                )
+            ),
+            'test_http': SecurityScheme(
+                http_auth_security_scheme=HTTPAuthSecurityScheme(
+                    description='HTTP Basic auth',
+                    scheme='basic',
+                    bearer_format='JWT',
+                )
+            ),
+            'test_oidc': SecurityScheme(
+                open_id_connect_security_scheme=OpenIdConnectSecurityScheme(
+                    description='OIDC Auth',
+                    open_id_connect_url='https://example.com/.well-known/openid-configuration',
+                )
+            ),
+            'test_mtls': SecurityScheme(
+                mtls_security_scheme=MutualTlsSecurityScheme(
+                    description='mTLS Auth'
+                )
+            ),
+        },
+        skills=[
+            AgentSkill(
+                id='skill-1',
+                name='Complex Skill 1',
+                description='The first complex skill',
+                tags=['example', 'complex'],
+                input_modes=['application/json'],
+                output_modes=['application/json'],
+                security_requirements=[
+                    SecurityRequirement(schemes={'test_api_key': StringList()})
+                ],
+            ),
+            AgentSkill(
+                id='skill-2',
+                name='Complex Skill 2',
+                description='The second complex skill',
+                tags=['example2'],
+                security_requirements=[
+                    SecurityRequirement(
+                        schemes={'test_oidc': StringList(list=['openid'])}
+                    )
+                ],
+            ),
+        ],
+    )
+
+    # 2. Minimal card
+    minimal_card = AgentCard(
+        name='Minimal Agent',
+        supported_interfaces=[
+            AgentInterface(
+                url='http://minimal.example.com',
+                protocol_binding='JSONRPC',
+                protocol_version='0.3.0',
+            )
+        ],
+    )
+
+    # 3. Serialize both
+    payload = {
+        'complex': json.dumps(agent_card_to_dict(complex_card)),
+        'minimal': json.dumps(agent_card_to_dict(minimal_card)),
+    }
+    payload_json = json.dumps(payload)
+
+    # 4. Feed it to the 0.3.24 SDK subprocess
+    result = subprocess.run(
+        [  # noqa: S607
+            'uv',
+            'run',
+            '--with',
+            'a2a-sdk==0.3.24',
+            '--no-project',
+            'python',
+            'tests/integration/cross_version/validate_agent_cards_030.py',
+        ],
+        input=payload_json,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # 5. Parse the response
+    payload_v030 = json.loads(result.stdout)
+    print(payload_v030['complex'])
+    cards_v030 = {
+        key: parse_agent_card(json.loads(card_json))
+        for key, card_json in payload_v030.items()
+    }
+
+    # 6. Validate the parsed cards from 0.3
+    def _remove_empty_capabilities(card):
+        if card['capabilities'] == {}:
+            card.pop('capabilities')
+        return card
+
+    assert _remove_empty_capabilities(
+        MessageToDict(cards_v030['minimal'])
+    ) == MessageToDict(minimal_card)
+    assert MessageToDict(cards_v030['complex']) == MessageToDict(complex_card)
+
+    # 7. Validate parsing of 1.0 cards with ParseDict
+    cards_v100 = {
+        key: ParseDict(
+            json.loads(card_json), AgentCard(), ignore_unknown_fields=True
+        )
+        for key, card_json in payload.items()
+    }
+    assert _remove_empty_capabilities(
+        MessageToDict(cards_v100['minimal'])
+    ) == MessageToDict(minimal_card)
+    assert MessageToDict(cards_v100['complex']) == MessageToDict(complex_card)

--- a/tests/integration/cross_version/validate_agent_cards_030.py
+++ b/tests/integration/cross_version/validate_agent_cards_030.py
@@ -1,0 +1,160 @@
+"""This is a script used by test_cross_version_card_validation.py.
+
+It is run in a subprocess with a SDK version 0.3.
+Steps:
+1. Read the serialized JSON payload from stdin.
+2. Validate the AgentCards with 0.3.24.
+3. Print re-serialized AgentCards to stdout.
+"""
+
+import sys
+import json
+from a2a.types import (
+    AgentCard,
+    AgentCapabilities,
+    AgentInterface,
+    AgentSkill,
+    APIKeySecurityScheme,
+    HTTPAuthSecurityScheme,
+    MutualTLSSecurityScheme,
+    OAuth2SecurityScheme,
+    OAuthFlows,
+    AuthorizationCodeOAuthFlow,
+    OpenIdConnectSecurityScheme,
+)
+
+
+def validate_complex_card(card: AgentCard) -> None:
+    expected_card = AgentCard(
+        name='Complex Agent 0.3',
+        description='A very complex agent from 0.3.0',
+        version='1.5.2',
+        protocolVersion='0.3.0',
+        supportsAuthenticatedExtendedCard=True,
+        capabilities=AgentCapabilities(streaming=True, pushNotifications=True),
+        url='http://complex.agent.example.com/api',
+        preferredTransport='HTTP+JSON',
+        additionalInterfaces=[
+            AgentInterface(
+                url='http://complex.agent.example.com/grpc',
+                transport='GRPC',
+            ),
+            AgentInterface(
+                url='http://complex.agent.example.com/jsonrpc',
+                transport='JSONRPC',
+            ),
+        ],
+        defaultInputModes=['text/plain', 'application/json'],
+        defaultOutputModes=['application/json', 'image/png'],
+        security=[
+            {'test_oauth': ['read', 'write'], 'test_api_key': []},
+            {'test_http': []},
+            {'test_oidc': ['openid', 'profile']},
+            {'test_mtls': []},
+        ],
+        securitySchemes={
+            'test_oauth': OAuth2SecurityScheme(
+                type='oauth2',
+                description='OAuth2 authentication',
+                flows=OAuthFlows(
+                    authorizationCode=AuthorizationCodeOAuthFlow(
+                        authorizationUrl='http://auth.example.com',
+                        tokenUrl='http://token.example.com',
+                        scopes={
+                            'read': 'Read access',
+                            'write': 'Write access',
+                        },
+                    )
+                ),
+            ),
+            'test_api_key': APIKeySecurityScheme(
+                type='apiKey',
+                description='API Key auth',
+                in_='header',
+                name='X-API-KEY',
+            ),
+            'test_http': HTTPAuthSecurityScheme(
+                type='http',
+                description='HTTP Basic auth',
+                scheme='basic',
+                bearerFormat='JWT',
+            ),
+            'test_oidc': OpenIdConnectSecurityScheme(
+                type='openIdConnect',
+                description='OIDC Auth',
+                openIdConnectUrl='https://example.com/.well-known/openid-configuration',
+            ),
+            'test_mtls': MutualTLSSecurityScheme(
+                type='mutualTLS', description='mTLS Auth'
+            ),
+        },
+        skills=[
+            AgentSkill(
+                id='skill-1',
+                name='Complex Skill 1',
+                description='The first complex skill',
+                tags=['example', 'complex'],
+                inputModes=['application/json'],
+                outputModes=['application/json'],
+                security=[{'test_api_key': []}],
+            ),
+            AgentSkill(
+                id='skill-2',
+                name='Complex Skill 2',
+                description='The second complex skill',
+                tags=['example2'],
+                security=[{'test_oidc': ['openid']}],
+            ),
+        ],
+    )
+
+    assert card == expected_card
+
+
+def validate_minimal_card(card: AgentCard) -> None:
+    expected_card = AgentCard(
+        name='Minimal Agent',
+        description='',
+        version='',
+        protocolVersion='0.3.0',
+        capabilities=AgentCapabilities(),
+        url='http://minimal.example.com',
+        preferredTransport='JSONRPC',
+        defaultInputModes=[],
+        defaultOutputModes=[],
+        skills=[],
+    )
+
+    assert card == expected_card
+
+
+def main() -> None:
+    # Read the serialized JSON payload from stdin
+    input_text = sys.stdin.read().strip()
+    if not input_text:
+        sys.exit(1)
+
+    try:
+        input_dict = json.loads(input_text)
+
+        complex_card = AgentCard.model_validate_json(input_dict['complex'])
+        validate_complex_card(complex_card)
+
+        minimal_card = AgentCard.model_validate_json(input_dict['minimal'])
+        validate_minimal_card(minimal_card)
+
+        payload = {
+            'complex': complex_card.model_dump_json(),
+            'minimal': minimal_card.model_dump_json(),
+        }
+        print(json.dumps(payload))
+
+    except Exception as e:
+        print(
+            f'Failed to validate AgentCards with 0.3.24: {e}', file=sys.stderr
+        )
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/server/apps/jsonrpc/test_serialization.py
+++ b/tests/server/apps/jsonrpc/test_serialization.py
@@ -55,7 +55,7 @@ def agent_card_with_api_key():
     """Provides an AgentCard with an APIKeySecurityScheme for testing serialization."""
     api_key_scheme = APIKeySecurityScheme(
         name='X-API-KEY',
-        location='IN_HEADER',
+        location='header',
     )
 
     security_scheme = SecurityScheme(api_key_security_scheme=api_key_scheme)

--- a/tests/server/request_handlers/test_jsonrpc_handler.py
+++ b/tests/server/request_handlers/test_jsonrpc_handler.py
@@ -1233,11 +1233,22 @@ class TestJSONRPCtHandler(unittest.async_case.IsolatedAsyncioTestCase):
         """Test error when authenticated extended agent card is not configured."""
         # Arrange
         mock_request_handler = AsyncMock(spec=DefaultRequestHandler)
-        # Mocking capabilities
-        self.mock_agent_card.capabilities = MagicMock()
-        self.mock_agent_card.capabilities.extended_agent_card = True
+        # We need a proper card here because agent_card_to_dict accesses multiple fields
+        card = AgentCard(
+            name='TestAgent',
+            version='1.0.0',
+            supported_interfaces=[
+                AgentInterface(
+                    url='http://localhost',
+                    protocol_binding='JSONRPC',
+                    protocol_version='1.0.0',
+                )
+            ],
+            capabilities=AgentCapabilities(extended_agent_card=True),
+        )
+
         handler = JSONRPCHandler(
-            self.mock_agent_card,
+            card,
             mock_request_handler,
             extended_agent_card=None,
             extended_card_modifier=None,
@@ -1309,7 +1320,9 @@ class TestJSONRPCtHandler(unittest.async_case.IsolatedAsyncioTestCase):
         self.assertFalse(is_error_response(response))
         from google.protobuf.json_format import ParseDict
 
-        modified_card = ParseDict(response['result'], AgentCard())
+        modified_card = ParseDict(
+            response['result'], AgentCard(), ignore_unknown_fields=True
+        )
         self.assertEqual(modified_card.name, 'Modified Card')
         self.assertEqual(modified_card.description, 'Modified for context: bar')
         self.assertEqual(modified_card.version, '1.0')

--- a/tests/server/request_handlers/test_response_helpers.py
+++ b/tests/server/request_handlers/test_response_helpers.py
@@ -3,15 +3,17 @@ import unittest
 from google.protobuf.json_format import MessageToDict
 
 from a2a.server.request_handlers.response_helpers import (
+    agent_card_to_dict,
     build_error_response,
     prepare_response_object,
 )
-from a2a.server.jsonrpc_models import JSONRPCError
 from a2a.types import (
     InvalidParamsError,
     TaskNotFoundError,
 )
 from a2a.types.a2a_pb2 import (
+    AgentCapabilities,
+    AgentCard,
     Task,
     TaskState,
     TaskStatus,
@@ -19,6 +21,29 @@ from a2a.types.a2a_pb2 import (
 
 
 class TestResponseHelpers(unittest.TestCase):
+    def test_agent_card_to_dict_without_extended_card(self) -> None:
+        card = AgentCard(
+            name='Test Agent',
+            description='Test Description',
+            version='1.0',
+            capabilities=AgentCapabilities(extended_agent_card=False),
+        )
+        result = agent_card_to_dict(card)
+        self.assertNotIn('supportsAuthenticatedExtendedCard', result)
+        self.assertEqual(result['name'], 'Test Agent')
+
+    def test_agent_card_to_dict_with_extended_card(self) -> None:
+        card = AgentCard(
+            name='Test Agent',
+            description='Test Description',
+            version='1.0',
+            capabilities=AgentCapabilities(extended_agent_card=True),
+        )
+        result = agent_card_to_dict(card)
+        self.assertIn('supportsAuthenticatedExtendedCard', result)
+        self.assertTrue(result['supportsAuthenticatedExtendedCard'])
+        self.assertEqual(result['name'], 'Test Agent')
+
     def test_build_error_response_with_a2a_error(self) -> None:
         request_id = 'req1'
         specific_error = TaskNotFoundError()

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -908,3 +908,29 @@ def test_non_dict_json(client: TestClient):
     data = response.json()
     assert 'error' in data
     assert data['error']['code'] == InvalidRequestError().code
+
+
+def test_agent_card_backward_compatibility_supports_extended_card(
+    agent_card: AgentCard, handler: mock.AsyncMock
+):
+    """Test that supportsAuthenticatedExtendedCard is injected when extended_agent_card is True."""
+    agent_card.capabilities.extended_agent_card = True
+    app_instance = A2AStarletteApplication(agent_card, handler)
+    client = TestClient(app_instance.build())
+    response = client.get(AGENT_CARD_WELL_KNOWN_PATH)
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get('supportsAuthenticatedExtendedCard') is True
+
+
+def test_agent_card_backward_compatibility_no_extended_card(
+    agent_card: AgentCard, handler: mock.AsyncMock
+):
+    """Test that supportsAuthenticatedExtendedCard is absent when extended_agent_card is False."""
+    agent_card.capabilities.extended_agent_card = False
+    app_instance = A2AStarletteApplication(agent_card, handler)
+    client = TestClient(app_instance.build())
+    response = client.get(AGENT_CARD_WELL_KNOWN_PATH)
+    assert response.status_code == 200
+    data = response.json()
+    assert 'supportsAuthenticatedExtendedCard' not in data


### PR DESCRIPTION
This commit implements the backwards compatibility helpers for exchanging legacy v0.3 Agent Cards across the v1.0 protocol bounds.

Also resolves linting and validation constraints.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [X] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [X] Appropriate docs were updated (if necessary)