### PR TITLE
fix: remove v1 from HTTP+REST/JSON paths

### DIFF
--- a/src/a2a/client/transports/rest.py
+++ b/src/a2a/client/transports/rest.py
@@ -78,7 +78,7 @@ class RestTransport(ClientTransport):
             request, context, extensions
         )
         response_data = await self._send_post_request(
-            '/v1/message:send', payload, modified_kwargs
+            '/message:send', payload, modified_kwargs
         )
         response: SendMessageResponse = ParseDict(
             response_data, SendMessageResponse()
@@ -99,7 +99,7 @@ class RestTransport(ClientTransport):
 
         async for event in self._send_stream_request(
             'POST',
-            '/v1/message:stream',
+            '/message:stream',
             http_kwargs=modified_kwargs,
             json=payload,
         ):
@@ -128,7 +128,7 @@ class RestTransport(ClientTransport):
             del params['id']  # id is part of the URL path, not query params
 
         response_data = await self._send_get_request(
-            f'/v1/tasks/{request.id}',
+            f'/tasks/{request.id}',
             params,
             modified_kwargs,
         )
@@ -153,7 +153,7 @@ class RestTransport(ClientTransport):
             extensions if extensions is not None else self.extensions,
         )
         response_data = await self._send_get_request(
-            '/v1/tasks',
+            '/tasks',
             _model_to_query_params(request),
             modified_kwargs,
         )
@@ -181,7 +181,7 @@ class RestTransport(ClientTransport):
             context,
         )
         response_data = await self._send_post_request(
-            f'/v1/tasks/{request.id}:cancel', payload, modified_kwargs
+            f'/tasks/{request.id}:cancel', payload, modified_kwargs
         )
         response: Task = ParseDict(response_data, Task())
         return response
@@ -203,7 +203,7 @@ class RestTransport(ClientTransport):
             payload, modified_kwargs, context
         )
         response_data = await self._send_post_request(
-            f'/v1/tasks/{request.task_id}/pushNotificationConfigs',
+            f'/tasks/{request.task_id}/pushNotificationConfigs',
             payload,
             modified_kwargs,
         )
@@ -235,7 +235,7 @@ class RestTransport(ClientTransport):
         if 'task_id' in params:
             del params['task_id']
         response_data = await self._send_get_request(
-            f'/v1/tasks/{request.task_id}/pushNotificationConfigs/{request.id}',
+            f'/tasks/{request.task_id}/pushNotificationConfigs/{request.id}',
             params,
             modified_kwargs,
         )
@@ -265,7 +265,7 @@ class RestTransport(ClientTransport):
         if 'task_id' in params:
             del params['task_id']
         response_data = await self._send_get_request(
-            f'/v1/tasks/{request.task_id}/pushNotificationConfigs',
+            f'/tasks/{request.task_id}/pushNotificationConfigs',
             params,
             modified_kwargs,
         )
@@ -297,7 +297,7 @@ class RestTransport(ClientTransport):
         if 'task_id' in params:
             del params['task_id']
         await self._send_delete_request(
-            f'/v1/tasks/{request.task_id}/pushNotificationConfigs/{request.id}',
+            f'/tasks/{request.task_id}/pushNotificationConfigs/{request.id}',
             params,
             modified_kwargs,
         )
@@ -317,7 +317,7 @@ class RestTransport(ClientTransport):
 
         async for event in self._send_stream_request(
             'GET',
-            f'/v1/tasks/{request.id}:subscribe',
+            f'/tasks/{request.id}:subscribe',
             http_kwargs=modified_kwargs,
         ):
             yield event
@@ -345,7 +345,7 @@ class RestTransport(ClientTransport):
             context,
         )
         response_data = await self._send_get_request(
-            '/v1/card', {}, modified_kwargs
+            '/card', {}, modified_kwargs
         )
         response: AgentCard = ParseDict(response_data, AgentCard())
 

--- a/src/a2a/server/apps/rest/rest_adapter.py
+++ b/src/a2a/server/apps/rest/rest_adapter.py
@@ -206,53 +206,53 @@ class RESTAdapter:
             the value is the callable handler for that route.
         """
         routes: dict[tuple[str, str], Callable[[Request], Any]] = {
-            ('/v1/message:send', 'POST'): functools.partial(
+            ('/message:send', 'POST'): functools.partial(
                 self._handle_request, self.handler.on_message_send
             ),
-            ('/v1/message:stream', 'POST'): functools.partial(
+            ('/message:stream', 'POST'): functools.partial(
                 self._handle_streaming_request,
                 self.handler.on_message_send_stream,
             ),
-            ('/v1/tasks/{id}:cancel', 'POST'): functools.partial(
+            ('/tasks/{id}:cancel', 'POST'): functools.partial(
                 self._handle_request, self.handler.on_cancel_task
             ),
-            ('/v1/tasks/{id}:subscribe', 'GET'): functools.partial(
+            ('/tasks/{id}:subscribe', 'GET'): functools.partial(
                 self._handle_streaming_request,
                 self.handler.on_subscribe_to_task,
             ),
-            ('/v1/tasks/{id}', 'GET'): functools.partial(
+            ('/tasks/{id}', 'GET'): functools.partial(
                 self._handle_request, self.handler.on_get_task
             ),
             (
-                '/v1/tasks/{id}/pushNotificationConfigs/{push_id}',
+                '/tasks/{id}/pushNotificationConfigs/{push_id}',
                 'GET',
             ): functools.partial(
                 self._handle_request, self.handler.get_push_notification
             ),
             (
-                '/v1/tasks/{id}/pushNotificationConfigs/{push_id}',
+                '/tasks/{id}/pushNotificationConfigs/{push_id}',
                 'DELETE',
             ): functools.partial(
                 self._handle_request, self.handler.delete_push_notification
             ),
             (
-                '/v1/tasks/{id}/pushNotificationConfigs',
+                '/tasks/{id}/pushNotificationConfigs',
                 'POST',
             ): functools.partial(
                 self._handle_request, self.handler.set_push_notification
             ),
             (
-                '/v1/tasks/{id}/pushNotificationConfigs',
+                '/tasks/{id}/pushNotificationConfigs',
                 'GET',
             ): functools.partial(
                 self._handle_request, self.handler.list_push_notifications
             ),
-            ('/v1/tasks', 'GET'): functools.partial(
+            ('/tasks', 'GET'): functools.partial(
                 self._handle_request, self.handler.list_tasks
             ),
         }
         if self.agent_card.capabilities.extended_agent_card:
-            routes[('/v1/card', 'GET')] = functools.partial(
+            routes[('/card', 'GET')] = functools.partial(
                 self._handle_request, self.handle_authenticated_agent_card
             )
 

--- a/src/a2a/server/request_handlers/rest_handler.py
+++ b/src/a2a/server/request_handlers/rest_handler.py
@@ -238,7 +238,7 @@ class RESTHandler:
         request: Request,
         context: ServerCallContext,
     ) -> dict[str, Any]:
-        """Handles the 'v1/tasks/{id}' REST method.
+        """Handles the 'tasks/{id}' REST method.
 
         Args:
             request: The incoming `Request` object.

--- a/tests/client/transports/test_rest_client.py
+++ b/tests/client/transports/test_rest_client.py
@@ -365,7 +365,7 @@ class TestTaskCallback:
         mock_build_request.assert_called_once()
         call_args = mock_build_request.call_args
         assert call_args[0][0] == 'GET'
-        assert f'/v1/tasks/{task_id}/pushNotificationConfigs' in call_args[0][1]
+        assert f'/tasks/{task_id}/pushNotificationConfigs' in call_args[0][1]
 
     @pytest.mark.asyncio
     async def test_delete_task_push_notification_config_success(
@@ -399,6 +399,6 @@ class TestTaskCallback:
         call_args = mock_build_request.call_args
         assert call_args[0][0] == 'DELETE'
         assert (
-            f'/v1/tasks/{task_id}/pushNotificationConfigs/config-1'
+            f'/tasks/{task_id}/pushNotificationConfigs/config-1'
             in call_args[0][1]
         )

--- a/tests/e2e/push_notifications/test_default_push_notification_support.py
+++ b/tests/e2e/push_notifications/test_default_push_notification_support.py
@@ -74,7 +74,7 @@ def agent_server(notifications_client: httpx.AsyncClient):
     )
     process.start()
     try:
-        wait_for_server_ready(f'{url}/v1/card')
+        wait_for_server_ready(f'{url}/card')
     except TimeoutError as e:
         process.terminate()
         raise e

--- a/tests/server/apps/rest/test_rest_fastapi_app.py
+++ b/tests/server/apps/rest/test_rest_fastapi_app.py
@@ -200,7 +200,7 @@ async def test_send_message_success_message(
     )
     # To see log output, run pytest with '--log-cli=true --log-cli-level=INFO'
     response = await client.post(
-        '/v1/message:send', json=json_format.MessageToDict(request)
+        '/message:send', json=json_format.MessageToDict(request)
     )
     # request should always be successful
     response.raise_for_status()
@@ -249,7 +249,7 @@ async def test_send_message_success_task(
     )
     # To see log output, run pytest with '--log-cli=true --log-cli-level=INFO'
     response = await client.post(
-        '/v1/message:send', json=json_format.MessageToDict(request)
+        '/message:send', json=json_format.MessageToDict(request)
     )
     # request should always be successful
     response.raise_for_status()
@@ -298,7 +298,7 @@ async def test_streaming_message_request_body_consumption(
 
     # This should not hang indefinitely (previously it would due to the deadlock)
     response = await streaming_client.post(
-        '/v1/message:stream',
+        '/message:stream',
         json=json_format.MessageToDict(request),
         headers={'Accept': 'text/event-stream'},
         timeout=10.0,  # Reasonable timeout to prevent hanging in tests
@@ -339,7 +339,7 @@ async def test_streaming_endpoint_with_invalid_content_type(
 
     # Send request without proper event-stream headers
     response = await streaming_client.post(
-        '/v1/message:stream',
+        '/message:stream',
         json=json_format.MessageToDict(request),
         timeout=10.0,
     )
@@ -387,7 +387,7 @@ async def test_send_message_rejected_task(
     )
 
     response = await client.post(
-        '/v1/message:send', json=json_format.MessageToDict(request)
+        '/message:send', json=json_format.MessageToDict(request)
     )
 
     response.raise_for_status()


### PR DESCRIPTION
This was removed in https://github.com/a2aproject/A2A/pull/1269 for `a2a.proto` and does not exist in [5.3. Method Mapping Reference](https://a2a-protocol.org/latest/specification/#53-method-mapping-reference).

Re #559.
