### PR TITLE
refactor: remove `extended_agent_card_url` parameter description

### DIFF
--- a/src/a2a/server/apps/rest/fastapi_app.py
+++ b/src/a2a/server/apps/rest/fastapi_app.py
@@ -99,7 +99,6 @@ class A2ARESTFastAPIApplication:
         Args:
             agent_card_url: The URL for the agent card endpoint.
             rpc_url: The URL for the A2A JSON-RPC endpoint.
-            extended_agent_card_url: The URL for the authenticated extended agent card endpoint.
             **kwargs: Additional keyword arguments to pass to the FastAPI constructor.
 
         Returns:


### PR DESCRIPTION
Parameter `extended_agent_card_url` does not exist in that method.
