### PR TITLE
fix(compat): allow DataPart.data to accept Any to align with spec

### DIFF
--- a/src/a2a/compat/v0_3/types.py
+++ b/src/a2a/compat/v0_3/types.py
@@ -274,7 +274,7 @@ class DataPart(A2ABaseModel):
     Represents a structured data segment (e.g., JSON) within a message or artifact.
     """
 
-    data: dict[str, Any]
+    data: Any
     """
     The structured data content.
     """


### PR DESCRIPTION

**Closes #714**

**Changes:**
- Updated `DataPart.data` type hint from `dict[str, Any]` to `Any` in `src/a2a/compat/v0_3/types.py`.

**Context:**
Following the 1.0-dev refactor, the `DataPart` class now resides in the `compat/v0_3` layer. This change ensures that the compatibility layer aligns with the A2A specification (where `data` can be an object, array, string, etc.). 

I verified that the new 1.0 `types` (generated from Protobuf) use the `Part` message, which already correctly handles these types.