### PR TITLE
build: use 1.0 tag in buf config

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,7 +2,7 @@
 version: v2
 inputs:
   - git_repo: https://github.com/a2aproject/A2A.git
-    ref: main
+    ref: v1.0.0
     subdir: specification
 managed:
   enabled: true


### PR DESCRIPTION
Point to https://github.com/a2aproject/A2A/releases/tag/v1.0.0.

Re #559, #706.