### PR TITLE
fix(client): prevent `ClientFactory.create()` from mutating shared config extensions

### DIFF
--- a/src/a2a/client/client_factory.py
+++ b/src/a2a/client/client_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 from collections.abc import Callable
@@ -239,15 +240,20 @@ class ClientFactory:
         all_extensions = self._config.extensions.copy()
         if extensions:
             all_extensions.extend(extensions)
-            self._config.extensions = all_extensions
+
+        config = (
+            dataclasses.replace(self._config, extensions=all_extensions)
+            if extensions
+            else self._config
+        )
 
         transport = self._registry[transport_protocol](
-            card, transport_url, self._config, interceptors or []
+            card, transport_url, config, interceptors or []
         )
 
         return BaseClient(
             card,
-            self._config,
+            config,
             transport,
             all_consumers,
             interceptors or [],

--- a/tests/client/test_client_factory.py
+++ b/tests/client/test_client_factory.py
@@ -266,3 +266,20 @@ async def test_client_factory_connect_with_consumers_and_interceptors(
         call_args = mock_base_client.call_args[0]
         assert call_args[3] == [consumer1]
         assert call_args[4] == [interceptor1]
+
+
+def test_client_factory_create_does_not_mutate_config_extensions(
+    base_agent_card: AgentCard,
+):
+    """Verify that calling create() with extensions does not mutate the factory's config."""
+    config = ClientConfig(
+        httpx_client=httpx.AsyncClient(),
+        extensions=['base-ext'],
+    )
+    factory = ClientFactory(config)
+
+    factory.create(base_agent_card, extensions=['ext-a'])
+    factory.create(base_agent_card, extensions=['ext-b'])
+
+    # Config should be unchanged — no accumulation
+    assert config.extensions == ['base-ext']


### PR DESCRIPTION
## Summary

- **Fix**: `ClientFactory.create()` was mutating `self._config.extensions` when called with per-client extensions, causing extensions to silently accumulate across calls.
- **Solution**: Use `dataclasses.replace()` to create a per-call config copy instead of mutating the shared `ClientConfig`. This matches the immutability pattern from #744.
- **Test**: Added regression test verifying that `config.extensions` remains unchanged after multiple `create()` calls with different extensions.

Fixes #858

## Test plan

- [x] New test `test_client_factory_create_does_not_mutate_config_extensions` verifies no mutation
- [x] All existing `test_client_factory.py` tests pass
- [x] `ruff check` and `ruff format` pass
- [x] `mypy` passes with no issues