### PR TITLE
ci: run tests on all active Python versions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -56,9 +56,9 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
 
-      # Coverage comparison for PRs (only on Python 3.13 to avoid duplicate work)
+      # Coverage comparison for PRs (only on Python 3.14 to avoid duplicate work)
       - name: Checkout Base Branch
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.14'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref || 'main' }}
@@ -68,33 +68,33 @@ jobs:
         run: uv sync --locked
 
       - name: Run coverage (Base)
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.14'
         run: |
           uv run pytest --cov=a2a --cov-report=json --cov-report=html:coverage
           mv coverage.json /tmp/coverage-base.json
 
       - name: Checkout PR Branch (Restore)
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.14'
         uses: actions/checkout@v4
         with:
           clean: true
 
       - name: Run coverage (PR)
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.14'
         run: |
           uv run pytest --cov=a2a --cov-report=json --cov-report=html:coverage --cov-report=term --cov-fail-under=88
           mv coverage.json coverage-pr.json
           cp /tmp/coverage-base.json coverage-base.json
 
       - name: Save Metadata
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.14'
         run: |
           echo ${{ github.event.number }} > ./PR_NUMBER
           echo ${{ github.event.pull_request.base.ref || 'main' }} > ./BASE_BRANCH
 
       - name: Upload Coverage Artifacts
         uses: actions/upload-artifact@v4
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.14'
         with:
           name: coverage-data
           path: |
@@ -107,12 +107,12 @@ jobs:
 
       # Run standard tests (for matrix items that didn't run coverage PR)
       - name: Run tests (Standard)
-        if: matrix.python-version != '3.13' || github.event_name != 'pull_request'
+        if: matrix.python-version != '3.14' || github.event_name != 'pull_request'
         run: uv run pytest --cov=a2a --cov-report term --cov-fail-under=88
 
       - name: Upload Artifact (base)
         uses: actions/upload-artifact@v4
-        if: github.event_name != 'pull_request' && matrix.python-version == '3.13'
+        if: github.event_name != 'pull_request' && matrix.python-version == '3.14'
         with:
           name: coverage-report
           path: coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Based on the current state of https://devguide.python.org/versions/.