### PR TITLE
refactor(client)!: Rename ClientFactory to A2AClientFactory

### DIFF
--- a/src/a2a/client/__init__.py
+++ b/src/a2a/client/__init__.py
@@ -16,7 +16,11 @@ from a2a.client.client import (
     ClientEvent,
     Consumer,
 )
-from a2a.client.client_factory import ClientFactory, minimal_agent_card
+from a2a.client.client_factory import (
+    A2AClientFactory,
+    ClientFactory,
+    minimal_agent_card,
+)
 from a2a.client.errors import (
     A2AClientError,
     A2AClientTimeoutError,
@@ -32,6 +36,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     'A2ACardResolver',
     'A2AClientError',
+    'A2AClientFactory',
     'A2AClientTimeoutError',
     'AgentCardResolutionError',
     'AuthInterceptor',

--- a/src/a2a/client/client_factory.py
+++ b/src/a2a/client/client_factory.py
@@ -55,15 +55,15 @@ TransportProducer = Callable[
 ]
 
 
-class ClientFactory:
-    """ClientFactory is used to generate the appropriate client for the agent.
+class A2AClientFactory:
+    """A2AClientFactory is used to generate the appropriate client for the agent.
 
     The factory is configured with a `ClientConfig` and optionally a list of
     `Consumer`s to use for all generated `Client`s. The expected use is:
 
     .. code-block:: python
 
-        factory = ClientFactory(config, consumers)
+        factory = A2AClientFactory(config, consumers)
         # Optionally register custom client implementations
         factory.register('my_customer_transport', NewCustomTransportClient)
         # Then with an agent card make a client with additional consumers and
@@ -101,7 +101,7 @@ class ClientFactory:
                 url: str,
                 config: ClientConfig,
             ) -> ClientTransport:
-                interface = ClientFactory._find_best_interface(
+                interface = A2AClientFactory._find_best_interface(
                     list(card.supported_interfaces),
                     protocol_bindings=[TransportProtocol.JSONRPC],
                     url=url,
@@ -140,7 +140,7 @@ class ClientFactory:
                 url: str,
                 config: ClientConfig,
             ) -> ClientTransport:
-                interface = ClientFactory._find_best_interface(
+                interface = A2AClientFactory._find_best_interface(
                     list(card.supported_interfaces),
                     protocol_bindings=[TransportProtocol.HTTP_JSON],
                     url=url,
@@ -186,7 +186,7 @@ class ClientFactory:
             ) -> ClientTransport:
                 # The interface has already been selected and passed as `url`.
                 # We determine its version to use the appropriate transport implementation.
-                interface = ClientFactory._find_best_interface(
+                interface = A2AClientFactory._find_best_interface(
                     list(card.supported_interfaces),
                     protocol_bindings=[TransportProtocol.GRPC],
                     url=url,
@@ -278,13 +278,13 @@ class ClientFactory:
 
         Constructs a client that connects to the specified agent. Note that
         creating multiple clients via this method is less efficient than
-        constructing an instance of ClientFactory and reusing that.
+        constructing an instance of A2AClientFactory and reusing that.
 
         .. code-block:: python
 
             # This will search for an AgentCard at /.well-known/agent-card.json
             my_agent_url = 'https://travel.agents.example.com'
-            client = await ClientFactory.connect(my_agent_url)
+            client = await A2AClientFactory.connect(my_agent_url)
 
 
         Args:
@@ -364,7 +364,7 @@ class ClientFactory:
         selected_interface = None
         if self._config.use_client_preference:
             for protocol_binding in client_set:
-                selected_interface = ClientFactory._find_best_interface(
+                selected_interface = A2AClientFactory._find_best_interface(
                     list(card.supported_interfaces),
                     protocol_bindings=[protocol_binding],
                 )
@@ -375,7 +375,7 @@ class ClientFactory:
             for supported_interface in card.supported_interfaces:
                 if supported_interface.protocol_binding in client_set:
                     transport_protocol = supported_interface.protocol_binding
-                    selected_interface = ClientFactory._find_best_interface(
+                    selected_interface = A2AClientFactory._find_best_interface(
                         list(card.supported_interfaces),
                         protocol_bindings=[transport_protocol],
                     )
@@ -432,3 +432,6 @@ def minimal_agent_card(
         version='',
         name='',
     )
+
+
+ClientFactory = A2AClientFactory


### PR DESCRIPTION
Completed task 555: Renamed `ClientFactory` to `A2AClientFactory` for backwards compatibility and spec alignment while auto-selecting transport based on `supportedInterfaces`. Exported both `ClientFactory` and `A2AClientFactory`.