### PR TITLE
fix(client): export TenantTransportDecorator and fix docstring

### DIFF
--- a/src/a2a/client/transports/__init__.py
+++ b/src/a2a/client/transports/__init__.py
@@ -3,6 +3,7 @@
 from a2a.client.transports.base import ClientTransport
 from a2a.client.transports.jsonrpc import JsonRpcTransport
 from a2a.client.transports.rest import RestTransport
+from a2a.client.transports.tenant_decorator import TenantTransportDecorator
 
 
 try:
@@ -16,4 +17,5 @@ __all__ = [
     'GrpcTransport',
     'JsonRpcTransport',
     'RestTransport',
+    'TenantTransportDecorator',
 ]

--- a/src/a2a/client/transports/tenant_decorator.py
+++ b/src/a2a/client/transports/tenant_decorator.py
@@ -43,7 +43,7 @@ class TenantTransportDecorator(ClientTransport):
         *,
         context: ClientCallContext | None = None,
     ) -> SendMessageResponse:
-        """Sends a streaming message request to the agent and yields responses as they arrive."""
+        """Sends a non-streaming message request to the agent."""
         request.tenant = self._resolve_tenant(request.tenant)
         return await self._base.send_message(request, context=context)
 

--- a/tests/client/transports/test_tenant_decorator.py
+++ b/tests/client/transports/test_tenant_decorator.py
@@ -127,3 +127,22 @@ class TestTenantTransportDecorator:
         async for _ in decorator.send_message_streaming(request_msg):
             pass
         assert request_msg.tenant == tenant_id
+
+    @pytest.mark.asyncio
+    async def test_close_delegates_to_base(
+        self, mock_transport: AsyncMock
+    ) -> None:
+        """Test that close() is delegated to the underlying transport."""
+        decorator = TenantTransportDecorator(mock_transport, 'test-tenant')
+        await decorator.close()
+        mock_transport.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(
+        self, mock_transport: AsyncMock
+    ) -> None:
+        """Test that the decorator works as an async context manager."""
+        decorator = TenantTransportDecorator(mock_transport, 'test-tenant')
+        async with decorator as transport:
+            assert transport is decorator
+        mock_transport.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

`TenantTransportDecorator` is used internally by `ClientFactory` to wrap transports when an `AgentInterface` specifies a tenant, but it is not exported from the `a2a.client.transports` package. This means users who need to compose transport decorators manually (e.g. stacking tenant resolution with a future `RetryTransport`) must import from the private module path.

This PR:

- **Exports `TenantTransportDecorator`** from `a2a.client.transports.__init__` and adds it to `__all__`, consistent with how `ClientTransport`, `JsonRpcTransport`, `RestTransport`, and `GrpcTransport` are exported.
- **Fixes the `send_message()` docstring** which incorrectly read *"Sends a streaming message request to the agent and yields responses as they arrive"* — a copy-paste from `send_message_streaming()`. Corrected to *"Sends a non-streaming message request to the agent."*
- **Adds test coverage for `close()` delegation** and async context manager usage, verifying the decorator properly delegates lifecycle management to the underlying transport.

## Test plan

- [x] All 14 `test_tenant_decorator.py` tests pass (12 existing + 2 new)
- [x] Verified `from a2a.client.transports import TenantTransportDecorator` resolves correctly