### PR TITLE
fix: update `with_a2a_extensions` to append instead of overwriting

### DIFF
--- a/src/a2a/client/service_parameters.py
+++ b/src/a2a/client/service_parameters.py
@@ -1,7 +1,10 @@
 from collections.abc import Callable
 from typing import TypeAlias
 
-from a2a.extensions.common import HTTP_EXTENSION_HEADER
+from a2a.extensions.common import (
+    HTTP_EXTENSION_HEADER,
+    get_requested_extensions,
+)
 
 
 ServiceParameters: TypeAlias = dict[str, str]
@@ -46,15 +49,26 @@ class ServiceParametersFactory:
 def with_a2a_extensions(extensions: list[str]) -> ServiceParametersUpdate:
     """Create a ServiceParametersUpdate that adds A2A extensions.
 
+    Merges the supplied URIs with any extensions already present in the
+    A2A-Extensions service parameter, deduplicating and producing a stable
+    (sorted) order. Calling this multiple times in a chain accumulates the
+    requested extensions instead of overwriting prior values.
+
     Args:
-        extensions: List of extension strings.
+        extensions: List of extension URIs to advertise.
 
     Returns:
         A function that updates ServiceParameters with the extensions header.
     """
 
     def update(parameters: ServiceParameters) -> None:
-        if extensions:
-            parameters[HTTP_EXTENSION_HEADER] = ','.join(extensions)
+        if not extensions:
+            return
+        existing = parameters.get(HTTP_EXTENSION_HEADER)
+        merged = sorted(
+            get_requested_extensions([existing] if existing else [])
+            | set(extensions)
+        )
+        parameters[HTTP_EXTENSION_HEADER] = ','.join(merged)
 
     return update

--- a/src/a2a/client/service_parameters.py
+++ b/src/a2a/client/service_parameters.py
@@ -47,28 +47,18 @@ class ServiceParametersFactory:
 
 
 def with_a2a_extensions(extensions: list[str]) -> ServiceParametersUpdate:
-    """Create a ServiceParametersUpdate that adds A2A extensions.
+    """Create a ServiceParametersUpdate that merges A2A extension URIs.
 
-    Merges the supplied URIs with any extensions already present in the
-    A2A-Extensions service parameter, deduplicating and producing a stable
-    (sorted) order. Calling this multiple times in a chain accumulates the
-    requested extensions instead of overwriting prior values.
-
-    Args:
-        extensions: List of extension URIs to advertise.
-
-    Returns:
-        A function that updates ServiceParameters with the extensions header.
+    Unions the supplied URIs with any already present in the A2A-Extensions
+    parameter, deduplicating and emitting them in sorted order. Repeated
+    calls accumulate rather than overwrite.
     """
 
     def update(parameters: ServiceParameters) -> None:
         if not extensions:
             return
-        existing = parameters.get(HTTP_EXTENSION_HEADER)
-        merged = sorted(
-            get_requested_extensions([existing] if existing else [])
-            | set(extensions)
-        )
+        existing = parameters.get(HTTP_EXTENSION_HEADER, '')
+        merged = sorted(get_requested_extensions([existing, *extensions]))
         parameters[HTTP_EXTENSION_HEADER] = ','.join(merged)
 
     return update

--- a/tests/client/test_service_parameters.py
+++ b/tests/client/test_service_parameters.py
@@ -1,0 +1,78 @@
+"""Tests for a2a.client.service_parameters module."""
+
+from a2a.client.service_parameters import (
+    ServiceParametersFactory,
+    with_a2a_extensions,
+)
+from a2a.extensions.common import HTTP_EXTENSION_HEADER
+
+
+def test_with_a2a_extensions_sets_header_when_empty():
+    """First call on empty parameters sets the joined URIs."""
+    parameters = ServiceParametersFactory.create(
+        [with_a2a_extensions(['ext-b', 'ext-a'])]
+    )
+
+    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b'
+
+
+def test_with_a2a_extensions_merges_disjoint_calls():
+    """A second call with disjoint URIs unions both sets."""
+    parameters = ServiceParametersFactory.create(
+        [
+            with_a2a_extensions(['ext-a']),
+            with_a2a_extensions(['ext-b']),
+        ]
+    )
+
+    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b'
+
+
+def test_with_a2a_extensions_deduplicates_overlapping():
+    """Overlapping URIs do not produce duplicates."""
+    parameters = ServiceParametersFactory.create(
+        [
+            with_a2a_extensions(['ext-a', 'ext-b']),
+            with_a2a_extensions(['ext-b', 'ext-c']),
+        ]
+    )
+
+    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b,ext-c'
+
+
+def test_with_a2a_extensions_empty_is_noop():
+    """Calling with an empty list leaves any existing header untouched."""
+    parameters = ServiceParametersFactory.create(
+        [
+            with_a2a_extensions(['ext-a']),
+            with_a2a_extensions([]),
+        ]
+    )
+
+    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a'
+
+
+def test_with_a2a_extensions_empty_does_not_create_header():
+    """Calling with an empty list on empty parameters adds nothing."""
+    parameters = ServiceParametersFactory.create([with_a2a_extensions([])])
+
+    assert HTTP_EXTENSION_HEADER not in parameters
+
+
+def test_with_a2a_extensions_output_is_sorted():
+    """Output ordering is deterministic (sorted) regardless of input order."""
+    parameters = ServiceParametersFactory.create(
+        [with_a2a_extensions(['c', 'a', 'b'])]
+    )
+
+    assert parameters[HTTP_EXTENSION_HEADER] == 'a,b,c'
+
+
+def test_with_a2a_extensions_merges_existing_header_value():
+    """Existing comma-separated header values are parsed and merged."""
+    base = ServiceParametersFactory.create_from(
+        {HTTP_EXTENSION_HEADER: 'ext-a, ext-b'},
+        [with_a2a_extensions(['ext-c'])],
+    )
+
+    assert base[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b,ext-c'

--- a/tests/client/test_service_parameters.py
+++ b/tests/client/test_service_parameters.py
@@ -7,41 +7,30 @@ from a2a.client.service_parameters import (
 from a2a.extensions.common import HTTP_EXTENSION_HEADER
 
 
-def test_with_a2a_extensions_sets_header_when_empty():
-    """First call on empty parameters sets the joined URIs."""
-    parameters = ServiceParametersFactory.create(
-        [with_a2a_extensions(['ext-b', 'ext-a'])]
-    )
-
-    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b'
-
-
-def test_with_a2a_extensions_merges_disjoint_calls():
-    """A second call with disjoint URIs unions both sets."""
+def test_with_a2a_extensions_merges_dedupes_and_sorts():
+    """Repeated calls accumulate; duplicates collapse; output is sorted."""
     parameters = ServiceParametersFactory.create(
         [
-            with_a2a_extensions(['ext-a']),
-            with_a2a_extensions(['ext-b']),
-        ]
-    )
-
-    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b'
-
-
-def test_with_a2a_extensions_deduplicates_overlapping():
-    """Overlapping URIs do not produce duplicates."""
-    parameters = ServiceParametersFactory.create(
-        [
-            with_a2a_extensions(['ext-a', 'ext-b']),
-            with_a2a_extensions(['ext-b', 'ext-c']),
+            with_a2a_extensions(['ext-c', 'ext-a']),
+            with_a2a_extensions(['ext-b', 'ext-a']),
         ]
     )
 
     assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b,ext-c'
 
 
+def test_with_a2a_extensions_merges_existing_header_value():
+    """Pre-existing comma-separated header values are parsed and merged."""
+    parameters = ServiceParametersFactory.create_from(
+        {HTTP_EXTENSION_HEADER: 'ext-a, ext-b'},
+        [with_a2a_extensions(['ext-c'])],
+    )
+
+    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b,ext-c'
+
+
 def test_with_a2a_extensions_empty_is_noop():
-    """Calling with an empty list leaves any existing header untouched."""
+    """An empty extensions list leaves the header untouched / absent."""
     parameters = ServiceParametersFactory.create(
         [
             with_a2a_extensions(['ext-a']),
@@ -50,29 +39,15 @@ def test_with_a2a_extensions_empty_is_noop():
     )
 
     assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a'
+    assert HTTP_EXTENSION_HEADER not in ServiceParametersFactory.create(
+        [with_a2a_extensions([])]
+    )
 
 
-def test_with_a2a_extensions_empty_does_not_create_header():
-    """Calling with an empty list on empty parameters adds nothing."""
-    parameters = ServiceParametersFactory.create([with_a2a_extensions([])])
-
-    assert HTTP_EXTENSION_HEADER not in parameters
-
-
-def test_with_a2a_extensions_output_is_sorted():
-    """Output ordering is deterministic (sorted) regardless of input order."""
+def test_with_a2a_extensions_normalizes_input_strings():
+    """Input strings are split on commas and stripped, like header values."""
     parameters = ServiceParametersFactory.create(
-        [with_a2a_extensions(['c', 'a', 'b'])]
+        [with_a2a_extensions(['ext-a, ext-b', '  ext-c  '])]
     )
 
-    assert parameters[HTTP_EXTENSION_HEADER] == 'a,b,c'
-
-
-def test_with_a2a_extensions_merges_existing_header_value():
-    """Existing comma-separated header values are parsed and merged."""
-    base = ServiceParametersFactory.create_from(
-        {HTTP_EXTENSION_HEADER: 'ext-a, ext-b'},
-        [with_a2a_extensions(['ext-c'])],
-    )
-
-    assert base[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b,ext-c'
+    assert parameters[HTTP_EXTENSION_HEADER] == 'ext-a,ext-b,ext-c'


### PR DESCRIPTION
Existing extensions are kept, enables better modularity of service parameters updates by (for instance) multiple interceptors.