### PR TITLE
fix: rely on agent executor implementation for stream termination

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler_v2.py
+++ b/src/a2a/server/request_handlers/default_request_handler_v2.py
@@ -279,7 +279,9 @@ class DefaultRequestHandlerV2(RequestHandler):
                 result = event
                 # Do NOT break here as Message is supposed to be the only
                 # event in "Message-only" interaction.
-                # We rely on AgentExecutor here to simplify wrong implementations detection.
+                # ActiveTask consumer (see active_task.py) validates the event
+                # stream and raises InvalidAgentResponseError if more events are
+                # pushed after a Message.
 
         if result is None:
             logger.debug('Missing result for task %s', request_context.task_id)
@@ -315,8 +317,12 @@ class DefaultRequestHandlerV2(RequestHandler):
             request=request_context,
             include_initial_task=False,
         ):
-            # Do NOT break here as we rely on AgentExecutor to yield control
-            # to simplify wrong implementations detection.
+            # Do NOT break here as we rely on AgentExecutor to yield control.
+            # ActiveTask consumer (see active_task.py) validates the event
+            # stream and raises InvalidAgentResponseError on misbehaving agents:
+            #   - an event after a Message
+            #   - Message after entering task mode
+            #   - an event after a terminal state
             if isinstance(event, Task):
                 self._validate_task_id_match(task_id, event.id)
                 yield apply_history_length(event, params.configuration)

--- a/src/a2a/server/request_handlers/default_request_handler_v2.py
+++ b/src/a2a/server/request_handlers/default_request_handler_v2.py
@@ -271,11 +271,15 @@ class DefaultRequestHandlerV2(RequestHandler):
             ):
                 self._validate_task_id_match(task_id, event.id)
                 result = event
+                # DO break here as it's "return_immediately".
+                # AgentExecutor will continue to run in the background.
                 break
 
             if isinstance(event, Message):
                 result = event
-                break
+                # Do NOT break here as Message is supposed to be the only
+                # event in "Message-only" interaction.
+                # We rely on AgentExecutor here to simplify wrong implementations detection.
 
         if result is None:
             logger.debug('Missing result for task %s', request_context.task_id)
@@ -311,14 +315,13 @@ class DefaultRequestHandlerV2(RequestHandler):
             request=request_context,
             include_initial_task=False,
         ):
+            # Do NOT break here as we rely on AgentExecutor to yield control
+            # to simplify wrong implementations detection.
             if isinstance(event, Task):
                 self._validate_task_id_match(task_id, event.id)
                 yield apply_history_length(event, params.configuration)
             else:
                 yield event
-
-            if isinstance(event, Message):
-                break
 
     @validate_request_params
     @validate(

--- a/tests/server/request_handlers/test_default_request_handler_v2.py
+++ b/tests/server/request_handlers/test_default_request_handler_v2.py
@@ -28,6 +28,7 @@ from a2a.server.tasks import (
 )
 from a2a.types import (
     InternalError,
+    InvalidAgentResponseError,
     InvalidParamsError,
     TaskNotFoundError,
     PushNotificationNotSupportedError,
@@ -1244,3 +1245,165 @@ async def test_on_message_send_with_push_notification():
     push_store.set_info.assert_awaited_once_with(
         result.id, push_config, context
     )
+
+
+class MultipleMessagesAgentExecutor(AgentExecutor):
+    """Misbehaving agent that yields more than one Message."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        await event_queue.enqueue_event(
+            new_text_message('first', role=Role.ROLE_AGENT)
+        )
+        await event_queue.enqueue_event(
+            new_text_message('second', role=Role.ROLE_AGENT)
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
+
+class MessageAfterTaskEventAgentExecutor(AgentExecutor):
+    """Misbehaving agent that yields a task-mode event then a Message."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        task = new_task_from_user_message(context.message)
+        await event_queue.enqueue_event(task)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.update_status(TaskState.TASK_STATE_WORKING)
+        await event_queue.enqueue_event(
+            new_text_message('stray message', role=Role.ROLE_AGENT)
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
+
+class TaskEventAfterMessageAgentExecutor(AgentExecutor):
+    """Misbehaving agent that yields a Message and then a task-mode event."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        await event_queue.enqueue_event(
+            new_text_message('only message', role=Role.ROLE_AGENT)
+        )
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                task_id=str(context.task_id or ''),
+                context_id=str(context.context_id or ''),
+                status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
+
+class EventAfterTerminalStateAgentExecutor(AgentExecutor):
+    """Misbehaving agent that yields an event after reaching a terminal state."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        task = new_task_from_user_message(context.message)
+        await event_queue.enqueue_event(task)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.complete()
+        await event_queue.enqueue_event(
+            new_text_message('after terminal', role=Role.ROLE_AGENT)
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(1)
+async def test_on_message_send_stream_rejects_multiple_messages():
+    """Stream surfaces InvalidAgentResponseError when the agent yields a
+    second Message after the first one (see comment in on_message_send_stream)."""
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=MultipleMessagesAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+        agent_card=create_default_agent_card(),
+    )
+    params = SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id='msg_multi_stream',
+            parts=[Part(text='Hi')],
+        )
+    )
+    with pytest.raises(InvalidAgentResponseError):
+        async for _ in request_handler.on_message_send_stream(
+            params, create_server_call_context()
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(1)
+async def test_on_message_send_stream_rejects_message_after_task_event():
+    """Stream surfaces InvalidAgentResponseError when the agent yields a
+    Message after entering task mode (see comment in on_message_send_stream)."""
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=MessageAfterTaskEventAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+        agent_card=create_default_agent_card(),
+    )
+    params = SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id='msg_after_task_stream',
+            parts=[Part(text='Hi')],
+        )
+    )
+    with pytest.raises(InvalidAgentResponseError):
+        async for _ in request_handler.on_message_send_stream(
+            params, create_server_call_context()
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(1)
+async def test_on_message_send_stream_rejects_task_event_after_message():
+    """Stream surfaces InvalidAgentResponseError when the agent yields a
+    task-mode event after a Message (see comment in on_message_send_stream)."""
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=TaskEventAfterMessageAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+        agent_card=create_default_agent_card(),
+    )
+    params = SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id='msg_then_task_stream',
+            parts=[Part(text='Hi')],
+        )
+    )
+    with pytest.raises(InvalidAgentResponseError):
+        async for _ in request_handler.on_message_send_stream(
+            params, create_server_call_context()
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(1)
+async def test_on_message_send_stream_rejects_event_after_terminal_state():
+    """Stream surfaces InvalidAgentResponseError when the agent yields an event
+    after reaching a terminal state (see comment in on_message_send_stream)."""
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=EventAfterTerminalStateAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+        agent_card=create_default_agent_card(),
+    )
+    params = SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id='msg_after_terminal_stream',
+            parts=[Part(text='Hi')],
+        )
+    )
+    with pytest.raises(InvalidAgentResponseError):
+        async for _ in request_handler.on_message_send_stream(
+            params, create_server_call_context()
+        ):
+            pass

--- a/tests/server/request_handlers/test_default_request_handler_v2.py
+++ b/tests/server/request_handlers/test_default_request_handler_v2.py
@@ -1330,7 +1330,7 @@ async def test_on_message_send_stream_rejects_multiple_messages():
             parts=[Part(text='Hi')],
         )
     )
-    with pytest.raises(InvalidAgentResponseError):
+    with pytest.raises(InvalidAgentResponseError, match='Multiple Message'):
         async for _ in request_handler.on_message_send_stream(
             params, create_server_call_context()
         ):
@@ -1354,7 +1354,9 @@ async def test_on_message_send_stream_rejects_message_after_task_event():
             parts=[Part(text='Hi')],
         )
     )
-    with pytest.raises(InvalidAgentResponseError):
+    with pytest.raises(
+        InvalidAgentResponseError, match='Message object in task mode'
+    ):
         async for _ in request_handler.on_message_send_stream(
             params, create_server_call_context()
         ):
@@ -1378,7 +1380,7 @@ async def test_on_message_send_stream_rejects_task_event_after_message():
             parts=[Part(text='Hi')],
         )
     )
-    with pytest.raises(InvalidAgentResponseError):
+    with pytest.raises(InvalidAgentResponseError, match='in message mode'):
         async for _ in request_handler.on_message_send_stream(
             params, create_server_call_context()
         ):
@@ -1402,7 +1404,9 @@ async def test_on_message_send_stream_rejects_event_after_terminal_state():
             parts=[Part(text='Hi')],
         )
     )
-    with pytest.raises(InvalidAgentResponseError):
+    with pytest.raises(
+        InvalidAgentResponseError, match='Message object in task mode'
+    ):
         async for _ in request_handler.on_message_send_stream(
             params, create_server_call_context()
         ):


### PR DESCRIPTION
`active_task.py` already contains agent executor behavior validation, do not terminate the stream so that those errors can be raised, tests are updated to cover invalid behavior conditions.