### PR TITLE
ci: fix release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.A2A_BOT_PAT }}
+          release-type: python


### PR DESCRIPTION
Set `release-type` as we removed configs in #995.