### PR TITLE
fix(proto): use field.label instead of is_repeated for protobuf compatibility

### DIFF
--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -174,9 +174,9 @@ def parse_params(params: QueryParams, message: ProtobufMessage) -> None:
         field = fields[k]
         v_list = params.getlist(k)
 
-        # TODO(https://github.com/a2aproject/a2a-python/issues/1011):
-        # Replace deprecated `field.label` with `field.is_repeated` once the
-        # minimum protobuf version requirement is bumped.
+        # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
+        # deprecated `field.label` with `field.is_repeated` once the minimum
+        # protobuf version requirement is bumped.
         if field.label == FieldDescriptor.LABEL_REPEATED:
             accumulated: list[Any] = []
             for v in v_list:
@@ -211,9 +211,9 @@ def _check_required_field_violation(
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011):
-    # Replace deprecated `field.label` with `field.is_repeated` once the
-    # minimum protobuf version requirement is bumped.
+    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
+    # deprecated `field.label` with `field.is_repeated` once the minimum
+    # protobuf version requirement is bumped.
     if field.label == FieldDescriptor.LABEL_REPEATED:
         if not val:
             return ValidationDetail(
@@ -255,9 +255,9 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011):
-    # Replace deprecated `field.label` with `field.is_repeated` once the
-    # minimum protobuf version requirement is bumped.
+    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
+    # deprecated `field.label` with `field.is_repeated` once the minimum
+    # protobuf version requirement is bumped.
     if field.label != FieldDescriptor.LABEL_REPEATED:
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)

--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -174,6 +174,9 @@ def parse_params(params: QueryParams, message: ProtobufMessage) -> None:
         field = fields[k]
         v_list = params.getlist(k)
 
+        # TODO(https://github.com/a2aproject/a2a-python/issues/1011):
+        # Replace deprecated `field.label` with `field.is_repeated` once the
+        # minimum protobuf version requirement is bumped.
         if field.label == FieldDescriptor.LABEL_REPEATED:
             accumulated: list[Any] = []
             for v in v_list:
@@ -208,6 +211,9 @@ def _check_required_field_violation(
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
+    # TODO(https://github.com/a2aproject/a2a-python/issues/1011):
+    # Replace deprecated `field.label` with `field.is_repeated` once the
+    # minimum protobuf version requirement is bumped.
     if field.label == FieldDescriptor.LABEL_REPEATED:
         if not val:
             return ValidationDetail(
@@ -249,6 +255,9 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
+    # TODO(https://github.com/a2aproject/a2a-python/issues/1011):
+    # Replace deprecated `field.label` with `field.is_repeated` once the
+    # minimum protobuf version requirement is bumped.
     if field.label != FieldDescriptor.LABEL_REPEATED:
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)

--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -174,7 +174,7 @@ def parse_params(params: QueryParams, message: ProtobufMessage) -> None:
         field = fields[k]
         v_list = params.getlist(k)
 
-        if field.label == field.LABEL_REPEATED:
+        if field.label == FieldDescriptor.LABEL_REPEATED:
             accumulated: list[Any] = []
             for v in v_list:
                 if not v:
@@ -208,7 +208,7 @@ def _check_required_field_violation(
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
-    if field.label == field.LABEL_REPEATED:
+    if field.label == FieldDescriptor.LABEL_REPEATED:
         if not val:
             return ValidationDetail(
                 field=field.name,
@@ -249,7 +249,7 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
-    if field.label != field.LABEL_REPEATED:
+    if field.label != FieldDescriptor.LABEL_REPEATED:
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)
             _append_nested_errors(errors, field.name, sub_errs)

--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -208,7 +208,7 @@ def _check_required_field_violation(
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
-    if field.is_repeated:
+    if field.label == field.LABEL_REPEATED:
         if not val:
             return ValidationDetail(
                 field=field.name,
@@ -249,7 +249,7 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
-    if not field.is_repeated:
+    if field.label != field.LABEL_REPEATED:
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)
             _append_nested_errors(errors, field.name, sub_errs)


### PR DESCRIPTION
# Description
Replace `field.is_repeated` with `field.label == field.LABEL_REPEATED` in `proto_utils.py` to support older protobuf versions where the `is_repeated` attribute is not available on `FieldDescriptor`.

# Problem
When using older protobuf versions accessing `field.is_repeated` raises:
`a2a.utils.errors.InternalError: 'google._upb._message.FieldDescriptor' object has no attribute 'is_repeated'`
The project's declared minimum is `protobuf>=5.29.5`,  `5.29.5` does not support `is_repeated`. This caused `send_message` (and other proto-validating client calls) to fail at runtime for users on older protobuf releases.
The `is_repeated` property was only added to `FieldDescriptor` in newer protobuf releases (6.x), so relying on it broke compatibility with the supported version range.

Although the deprecated label was already [removed in some 7.x version](https://github.com/protocolbuffers/protobuf/releases/tag/v34.0-rc1.1), 7.x version can't be resolved with the other constraints we have in the project.

# Fix
Use the long-standing `label` attribute and compare against `FieldDescriptor.LABEL_REPEATED`, which is available across all supported protobuf versions and is the canonical way to detect repeated fields.

# Testing
- `uv run pytest` passes against the supported protobuf version range.
