### PR TITLE
fix: add exclude_list to @trace_class on high-frequency event classes

### DIFF
--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -18,7 +18,10 @@ from a2a.utils.telemetry import SpanKind, trace_class
 logger = logging.getLogger(__name__)
 
 
-@trace_class(kind=SpanKind.SERVER)
+@trace_class(
+    kind=SpanKind.SERVER,
+    exclude_list=['consume_all'],
+)
 class EventConsumer:
     """Consumer to read events from the agent event queue."""
 

--- a/src/a2a/server/events/event_queue.py
+++ b/src/a2a/server/events/event_queue.py
@@ -93,7 +93,10 @@ class EventQueue(ABC):
         """
 
 
-@trace_class(kind=SpanKind.SERVER)
+@trace_class(
+    kind=SpanKind.SERVER,
+    exclude_list=['enqueue_event', 'dequeue_event', 'task_done', 'is_closed'],
+)
 class EventQueueLegacy(EventQueue):
     """Event queue for A2A responses from agent.
 

--- a/src/a2a/server/events/event_queue_v2.py
+++ b/src/a2a/server/events/event_queue_v2.py
@@ -20,7 +20,10 @@ from a2a.utils.telemetry import SpanKind, trace_class
 logger = logging.getLogger(__name__)
 
 
-@trace_class(kind=SpanKind.SERVER)
+@trace_class(
+    kind=SpanKind.SERVER,
+    exclude_list=['enqueue_event', 'dequeue_event', 'task_done', 'is_closed'],
+)
 class EventQueueSource(EventQueue):
     """The Parent EventQueue.
 

--- a/src/a2a/server/events/in_memory_queue_manager.py
+++ b/src/a2a/server/events/in_memory_queue_manager.py
@@ -9,7 +9,10 @@ from a2a.server.events.queue_manager import (
 from a2a.utils.telemetry import SpanKind, trace_class
 
 
-@trace_class(kind=SpanKind.SERVER)
+@trace_class(
+    kind=SpanKind.SERVER,
+    exclude_list=['add', 'get', 'create_or_tap'],
+)
 class InMemoryQueueManager(QueueManager):
     """InMemoryQueueManager is used for a single binary management.
 


### PR DESCRIPTION
## Summary

Fixes #1034 — `@trace_class(kind=SpanKind.SERVER)` on `EventQueue` and related classes generates **1500+ spans per LLM streaming session** from high-frequency internal methods (`enqueue_event`, `dequeue_event`, `task_done`, etc.).

## Changes

Added `exclude_list` to `@trace_class` on 4 classes in `a2a/server/events/`:

| Class | File | Excluded Methods |
|-------|------|------------------|
| `EventQueueLegacy` | `event_queue.py` | `enqueue_event`, `dequeue_event`, `task_done`, `is_closed` |
| `EventQueueSource` | `event_queue_v2.py` | `enqueue_event`, `dequeue_event`, `task_done`, `is_closed` |
| `EventConsumer` | `event_consumer.py` | `consume_all` |
| `InMemoryQueueManager` | `in_memory_queue_manager.py` | `add`, `get`, `create_or_tap` |

## Impact

- **97% span reduction** — from 1500+ to ~53 spans per session
- Preserves all useful `RequestHandler`-level traces (`DefaultRequestHandler`, `JSONRPCHandler`, `RESTHandler`)
- Uses the existing `exclude_list` parameter in `trace_class` — no new API surface or breaking changes
- Unblocks span-quota-limited systems (e.g., AWS Bedrock AgentCore Online Evaluation 1000-span limit)

## Testing

- All 106 event-related tests pass (`pytest -k 'event_queue or event_consumer or queue_manager or telemetry'`)
- 3 xfailed tests are pre-existing (#869)