### PR TITLE
fix(proto-utils): use FieldDescriptor.is_repeated instead of removed .label

### DIFF
--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -174,10 +174,7 @@ def parse_params(params: QueryParams, message: ProtobufMessage) -> None:
         field = fields[k]
         v_list = params.getlist(k)
 
-        # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-        # deprecated `field.label` with `field.is_repeated` once the minimum
-        # protobuf version requirement is bumped.
-        if field.label == FieldDescriptor.LABEL_REPEATED:
+        if field.is_repeated:
             accumulated: list[Any] = []
             for v in v_list:
                 if not v:
@@ -211,10 +208,7 @@ def _check_required_field_violation(
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-    # deprecated `field.label` with `field.is_repeated` once the minimum
-    # protobuf version requirement is bumped.
-    if field.label == FieldDescriptor.LABEL_REPEATED:
+    if field.is_repeated:
         if not val:
             return ValidationDetail(
                 field=field.name,
@@ -255,10 +249,7 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-    # deprecated `field.label` with `field.is_repeated` once the minimum
-    # protobuf version requirement is bumped.
-    if field.label != FieldDescriptor.LABEL_REPEATED:
+    if not field.is_repeated:
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)
             _append_nested_errors(errors, field.name, sub_errs)


### PR DESCRIPTION
## Summary

Three call sites in `proto_utils.py` use `FieldDescriptor.label`, which protobuf 7.x removed from both the upb and pure-Python backends. Every JSON-RPC method that runs through the request handler raises `AttributeError` before the agent executor is ever called:

```
File "a2a/utils/proto_utils.py", line 217, in _check_required_field_violation
    if field.label == FieldDescriptor.LABEL_REPEATED:
AttributeError: 'FieldDescriptor' object has no attribute 'label'
```

The code already had TODOs referencing #1011 with the exact intended fix ("Replace deprecated `field.label` with `field.is_repeated` once the minimum protobuf version requirement is bumped"). Since the package's `protobuf>=5.29.5` floor is well past the version that supports `is_repeated`, we can land the swap now.

## Changes

- `parse_query_params_to_proto` (was line 180): body request parsing
- `_check_required_field_violation` (was line 217): required-field validator
- `_recurse_validation` (was line 261): nested-message validator

Each `field.label == FieldDescriptor.LABEL_REPEATED` becomes `field.is_repeated`, and the inverse `!=` becomes `not field.is_repeated`. The corresponding TODO comments are removed.

## Test plan

- [x] Confirmed locally that `validate_proto_required_fields` fails on protobuf 7.34.1 against `a2a-sdk==1.0.2` without the patch
- [x] Confirmed integration into a downstream FastAPI server (Pictomancer.ai gateway, JSON-RPC endpoint) works end-to-end after applying the patch — `message/send`, `tasks/get`, `agent/getAuthenticatedExtendedCard` all return correctly
- [ ] CI here will run the existing `tests/utils/test_proto_utils.py` and `tests/compat/v0_3/test_proto_utils.py` suites, which should still pass (the change is semantically equivalent on protobuf versions that have both attributes)

Closes #1011