### PR TITLE
fix: Improve task_push_notification_config presence check.

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -301,10 +301,8 @@ class LegacyRequestHandler(RequestHandler):
         # dictating the task ID at this layer is useful for tracking running
         # agents.
 
-        if (
-            self._push_config_store
-            and params.configuration
-            and params.configuration.task_push_notification_config
+        if self._push_config_store and params.configuration.HasField(
+            'task_push_notification_config'
         ):
             await self._push_config_store.set_info(
                 task_id,

--- a/src/a2a/server/request_handlers/default_request_handler_v2.py
+++ b/src/a2a/server/request_handlers/default_request_handler_v2.py
@@ -209,10 +209,8 @@ class DefaultRequestHandlerV2(RequestHandler):
         task_id = cast('str', request_context.task_id)
         context_id = cast('str', request_context.context_id)
 
-        if (
-            self._push_config_store
-            and params.configuration
-            and params.configuration.task_push_notification_config
+        if self._push_config_store and params.configuration.HasField(
+            'task_push_notification_config'
         ):
             await self._push_config_store.set_info(
                 task_id,

--- a/tests/server/request_handlers/test_default_request_handler_v2.py
+++ b/tests/server/request_handlers/test_default_request_handler_v2.py
@@ -1247,6 +1247,36 @@ async def test_on_message_send_with_push_notification():
     )
 
 
+@pytest.mark.asyncio
+async def test_on_message_send_with_empty_push_notification_config_does_not_call_set_info():
+    task_store = InMemoryTaskStore()
+    push_store = AsyncMock(spec=PushNotificationConfigStore)
+
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=HelloAgentExecutor(),
+        task_store=task_store,
+        push_config_store=push_store,
+        agent_card=create_default_agent_card(),
+    )
+    # Use empty SendMessageConfiguration where task_push_notification_config is NOT set explicitly.
+    # Proto3 makes accessing it return a truthy default instance.
+    params = SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id='msg_push_empty',
+            parts=[Part(text='Hi')],
+        ),
+        configuration=SendMessageConfiguration(),
+    )
+
+    context = create_server_call_context()
+    result = await request_handler.on_message_send(params, context)
+
+    assert result is not None
+    assert isinstance(result, Task)
+    push_store.set_info.assert_not_called()
+
+
 class MultipleMessagesAgentExecutor(AgentExecutor):
     """Misbehaving agent that yields more than one Message."""
 


### PR DESCRIPTION
Call _push_config_store.set_info only when task_push_notification_config is set.

Due to proto3 semantic bool(params.configuration.task_push_notification_config) was always True.

Fixes #1045 🦕
