### PR TITLE
fix(errors): align error mappings with A2A spec 

### DIFF
--- a/src/a2a/server/request_handlers/grpc_handler.py
+++ b/src/a2a/server/request_handlers/grpc_handler.py
@@ -89,13 +89,13 @@ _ERROR_CODE_MAP: dict[type[A2AError], grpc.StatusCode] = {
     types.InternalError: grpc.StatusCode.INTERNAL,
     types.TaskNotFoundError: grpc.StatusCode.NOT_FOUND,
     types.TaskNotCancelableError: grpc.StatusCode.FAILED_PRECONDITION,
-    types.PushNotificationNotSupportedError: grpc.StatusCode.UNIMPLEMENTED,
-    types.UnsupportedOperationError: grpc.StatusCode.UNIMPLEMENTED,
+    types.PushNotificationNotSupportedError: grpc.StatusCode.FAILED_PRECONDITION,
+    types.UnsupportedOperationError: grpc.StatusCode.FAILED_PRECONDITION,
     types.ContentTypeNotSupportedError: grpc.StatusCode.INVALID_ARGUMENT,
     types.InvalidAgentResponseError: grpc.StatusCode.INTERNAL,
     types.ExtendedAgentCardNotConfiguredError: grpc.StatusCode.FAILED_PRECONDITION,
     types.ExtensionSupportRequiredError: grpc.StatusCode.FAILED_PRECONDITION,
-    types.VersionNotSupportedError: grpc.StatusCode.UNIMPLEMENTED,
+    types.VersionNotSupportedError: grpc.StatusCode.FAILED_PRECONDITION,
 }
 
 

--- a/src/a2a/utils/errors.py
+++ b/src/a2a/utils/errors.py
@@ -149,23 +149,23 @@ JSON_RPC_ERROR_CODE_MAP: dict[type[A2AError], int] = {
 A2A_REST_ERROR_MAPPING: dict[type[A2AError], RestErrorMap] = {
     TaskNotFoundError: RestErrorMap(404, 'NOT_FOUND', 'TASK_NOT_FOUND'),
     TaskNotCancelableError: RestErrorMap(
-        409, 'FAILED_PRECONDITION', 'TASK_NOT_CANCELABLE'
+        400, 'FAILED_PRECONDITION', 'TASK_NOT_CANCELABLE'
     ),
     PushNotificationNotSupportedError: RestErrorMap(
         400,
-        'UNIMPLEMENTED',
+        'FAILED_PRECONDITION',
         'PUSH_NOTIFICATION_NOT_SUPPORTED',
     ),
     UnsupportedOperationError: RestErrorMap(
-        400, 'UNIMPLEMENTED', 'UNSUPPORTED_OPERATION'
+        400, 'FAILED_PRECONDITION', 'UNSUPPORTED_OPERATION'
     ),
     ContentTypeNotSupportedError: RestErrorMap(
-        415,
+        400,
         'INVALID_ARGUMENT',
         'CONTENT_TYPE_NOT_SUPPORTED',
     ),
     InvalidAgentResponseError: RestErrorMap(
-        502, 'INTERNAL', 'INVALID_AGENT_RESPONSE'
+        500, 'INTERNAL', 'INVALID_AGENT_RESPONSE'
     ),
     ExtendedAgentCardNotConfiguredError: RestErrorMap(
         400,
@@ -178,7 +178,7 @@ A2A_REST_ERROR_MAPPING: dict[type[A2AError], RestErrorMap] = {
         'EXTENSION_SUPPORT_REQUIRED',
     ),
     VersionNotSupportedError: RestErrorMap(
-        400, 'UNIMPLEMENTED', 'VERSION_NOT_SUPPORTED'
+        400, 'FAILED_PRECONDITION', 'VERSION_NOT_SUPPORTED'
     ),
     InvalidParamsError: RestErrorMap(400, 'INVALID_ARGUMENT', 'INVALID_PARAMS'),
     InvalidRequestError: RestErrorMap(

--- a/tests/server/request_handlers/test_grpc_handler.py
+++ b/tests/server/request_handlers/test_grpc_handler.py
@@ -334,12 +334,12 @@ async def test_list_tasks_success(
         ),
         (
             types.PushNotificationNotSupportedError(),
-            grpc.StatusCode.UNIMPLEMENTED,
+            grpc.StatusCode.FAILED_PRECONDITION,
             'PushNotificationNotSupportedError',
         ),
         (
             types.UnsupportedOperationError(),
-            grpc.StatusCode.UNIMPLEMENTED,
+            grpc.StatusCode.FAILED_PRECONDITION,
             'UnsupportedOperationError',
         ),
         (


### PR DESCRIPTION
# Description
Aligns A2A error mappings with the canonical mapping in [A2A spec](https://a2a-protocol.org/latest/specification/#54-error-code-mappings). 
# Changes
- `grpc_handler.py` _ERROR_CODE_MAP: PushNotificationNotSupportedError, UnsupportedOperationError, VersionNotSupportedError → FAILED_PRECONDITION (was UNIMPLEMENTED).
- `errors.py` A2A_REST_ERROR_MAPPING: same three errors' gRPC status updated to FAILED_PRECONDITION; TaskNotCancelableError HTTP 409 → 400; InvalidAgentResponseError HTTP 502 → 500.
- `test_grpc_handler.py`: updated parametrized expectations for the two affected gRPC test cases.

Issue #1027 🦕
