### PR TITLE
feat(client): add ArtifactsAggregator for assembling artifacts from stream

### DIFF
--- a/docs/migrations/v1_0/README.md
+++ b/docs/migrations/v1_0/README.md
@@ -564,7 +564,7 @@ from a2a.client import ArtifactsAggregator
 
 # Assemble a single artifact by ID
 # Note: each ArtifactsAggregator instance consumes the stream once — create a new instance per operation
-aggregator = ArtifactsAggregator.from_stream(client.send_message(request))
+aggregator = ArtifactsAggregator(client.send_message(request))
 artifact = await aggregator.get_artifact('my-artifact-id')
 if artifact is not None:
     for part in artifact.parts:
@@ -572,7 +572,7 @@ if artifact is not None:
 
 
 # Or assemble all artifacts from the stream — requires a new request and a new aggregator instance
-aggregator = ArtifactsAggregator.from_stream(client.send_message(request))
+aggregator = ArtifactsAggregator(client.send_message(request))
 artifacts = await aggregator.get_all_artifacts()
 ```
 

--- a/docs/migrations/v1_0/README.md
+++ b/docs/migrations/v1_0/README.md
@@ -557,6 +557,24 @@ async for chunk in client.send_message(request):
         ...
 ```
 
+Alternatively, use the `ArtifactsAggregator` helper to automatically assemble artifacts from the stream:
+
+```python
+from a2a.client import ArtifactsAggregator
+
+# Assemble a single artifact by ID
+# Note: each ArtifactsAggregator instance consumes the stream once — create a new instance per operation
+aggregator = ArtifactsAggregator.from_stream(client.send_message(request))
+artifact = await aggregator.get_artifact('my-artifact-id')
+if artifact is not None:
+    for part in artifact.parts:
+        print(part.text)
+
+
+# Or assemble all artifacts from the stream — requires a new request and a new aggregator instance
+aggregator = ArtifactsAggregator.from_stream(client.send_message(request))
+artifacts = await aggregator.get_all_artifacts()
+```
 
 ---
 

--- a/src/a2a/client/__init__.py
+++ b/src/a2a/client/__init__.py
@@ -1,5 +1,6 @@
 """Client-side components for interacting with an A2A agent."""
 
+from a2a.client.artifact_aggregator import ArtifactsAggregator
 from a2a.client.auth import (
     AuthInterceptor,
     CredentialService,
@@ -30,6 +31,7 @@ __all__ = [
     'A2AClientError',
     'A2AClientTimeoutError',
     'AgentCardResolutionError',
+    'ArtifactsAggregator',
     'AuthInterceptor',
     'BaseClient',
     'Client',

--- a/src/a2a/client/artifact_aggregator.py
+++ b/src/a2a/client/artifact_aggregator.py
@@ -14,21 +14,6 @@ class ArtifactsAggregator:
     def __init__(self, stream: AsyncIterator[StreamResponse]) -> None:
         self._stream = stream
 
-    @classmethod
-    def from_stream(
-        cls, stream: AsyncIterator[StreamResponse]
-    ) -> 'ArtifactsAggregator':
-        """Create an ArtifactsAggregator from an async stream of StreamResponse events.
-
-        Args:
-            stream: An async iterator of StreamResponse objects, typically obtained
-                from BaseClient.send_message.
-
-        Returns:
-            A new ArtifactsAggregator instance.
-        """
-        return cls(stream)
-
     async def get_artifact(self, artifact_id: str) -> Artifact | None:
         """Assemble and return a single Artifact by its ID from the stream.
 

--- a/src/a2a/client/artifact_aggregator.py
+++ b/src/a2a/client/artifact_aggregator.py
@@ -1,0 +1,96 @@
+from collections.abc import AsyncIterator
+
+from a2a.types import Artifact, StreamResponse
+
+
+class ArtifactsAggregator:
+    """Client-side utility for assembling Artifact objects from a stream of StreamResponse events.
+
+    Interprets the append and last_chunk flags of TaskArtifactUpdateEvent to
+    reconstruct complete artifacts from chunked streaming responses. Each instance
+    wraps a single stream that can be consumed only once.
+    """
+
+    def __init__(self, stream: AsyncIterator[StreamResponse]) -> None:
+        self._stream = stream
+
+    @classmethod
+    def from_stream(
+        cls, stream: AsyncIterator[StreamResponse]
+    ) -> 'ArtifactsAggregator':
+        return cls(stream)
+
+    async def get_artifact(self, artifact_id: str) -> Artifact | None:
+        """Assemble and return a single Artifact by its ID from the stream.
+
+        Iterates over the stream and collects all parts belonging to the artifact
+        with the given ID, stopping when last_chunk is True.
+
+        Args:
+            artifact_id: The ID of the artifact to assemble.
+
+        Returns:
+            The assembled Artifact with all collected parts,
+            or None if the artifact_id was not found in the stream.
+
+        Note:
+            Consumes the stream. Do not call this method and get_all_artifacts
+            on the same instance.
+        """
+        artifact = None
+
+        async for event in self._stream:
+            if not event.HasField('artifact_update'):
+                continue
+
+            if event.artifact_update.artifact.artifact_id == artifact_id:
+                if artifact is None or not event.artifact_update.append:
+                    artifact = Artifact(
+                        name=event.artifact_update.artifact.name,
+                        description=event.artifact_update.artifact.description,
+                        metadata=event.artifact_update.artifact.metadata,
+                        extensions=event.artifact_update.artifact.extensions,
+                        artifact_id=artifact_id,
+                    )
+
+                artifact.parts.extend(event.artifact_update.artifact.parts)
+                if event.artifact_update.last_chunk:
+                    break
+        return artifact
+
+    async def get_all_artifacts(self) -> list[Artifact]:
+        """Assemble and return all Artifacts from the stream.
+
+        Iterates over the entire stream and assembles all artifacts, handling
+        interleaved chunks from multiple artifacts using artifact_id as the key.
+        If append is False, the parts for that artifact are reset before adding
+        the new parts.
+
+        Returns:
+            A list of assembled Artifact objects.
+
+        Note:
+            Consumes the stream. Do not call this method and get_artifact
+            on the same instance.
+        """
+        artifacts: dict[str, Artifact] = {}
+
+        async for event in self._stream:
+            if not event.HasField('artifact_update'):
+                continue
+
+            artifact_id = event.artifact_update.artifact.artifact_id
+
+            if artifact_id not in artifacts or not event.artifact_update.append:
+                artifacts[artifact_id] = Artifact(
+                    name=event.artifact_update.artifact.name,
+                    description=event.artifact_update.artifact.description,
+                    metadata=event.artifact_update.artifact.metadata,
+                    extensions=event.artifact_update.artifact.extensions,
+                    artifact_id=artifact_id,
+                )
+
+            artifacts[artifact_id].parts.extend(
+                event.artifact_update.artifact.parts
+            )
+        return list(artifacts.values())

--- a/src/a2a/client/artifact_aggregator.py
+++ b/src/a2a/client/artifact_aggregator.py
@@ -18,6 +18,15 @@ class ArtifactsAggregator:
     def from_stream(
         cls, stream: AsyncIterator[StreamResponse]
     ) -> 'ArtifactsAggregator':
+        """Create an ArtifactsAggregator from an async stream of StreamResponse events.
+
+        Args:
+            stream: An async iterator of StreamResponse objects, typically obtained
+                from BaseClient.send_message.
+
+        Returns:
+            A new ArtifactsAggregator instance.
+        """
         return cls(stream)
 
     async def get_artifact(self, artifact_id: str) -> Artifact | None:
@@ -45,15 +54,11 @@ class ArtifactsAggregator:
 
             if event.artifact_update.artifact.artifact_id == artifact_id:
                 if artifact is None or not event.artifact_update.append:
-                    artifact = Artifact(
-                        name=event.artifact_update.artifact.name,
-                        description=event.artifact_update.artifact.description,
-                        metadata=event.artifact_update.artifact.metadata,
-                        extensions=event.artifact_update.artifact.extensions,
-                        artifact_id=artifact_id,
-                    )
+                    artifact = Artifact()
+                    artifact.CopyFrom(event.artifact_update.artifact)
+                else:
+                    artifact.parts.extend(event.artifact_update.artifact.parts)
 
-                artifact.parts.extend(event.artifact_update.artifact.parts)
                 if event.artifact_update.last_chunk:
                     break
         return artifact
@@ -82,15 +87,10 @@ class ArtifactsAggregator:
             artifact_id = event.artifact_update.artifact.artifact_id
 
             if artifact_id not in artifacts or not event.artifact_update.append:
-                artifacts[artifact_id] = Artifact(
-                    name=event.artifact_update.artifact.name,
-                    description=event.artifact_update.artifact.description,
-                    metadata=event.artifact_update.artifact.metadata,
-                    extensions=event.artifact_update.artifact.extensions,
-                    artifact_id=artifact_id,
+                artifacts[artifact_id] = Artifact()
+                artifacts[artifact_id].CopyFrom(event.artifact_update.artifact)
+            else:
+                artifacts[artifact_id].parts.extend(
+                    event.artifact_update.artifact.parts
                 )
-
-            artifacts[artifact_id].parts.extend(
-                event.artifact_update.artifact.parts
-            )
         return list(artifacts.values())

--- a/tests/client/test_artifact_aggregator.py
+++ b/tests/client/test_artifact_aggregator.py
@@ -130,7 +130,7 @@ class TestArtifactsAggregator:
 
         request = SendMessageRequest(message=sample_message)
 
-        artifact_aggregator = ArtifactsAggregator.from_stream(
+        artifact_aggregator = ArtifactsAggregator(
             base_client.send_message(request)
         )
         artifact = await artifact_aggregator.get_artifact('artifact-1')
@@ -170,7 +170,7 @@ class TestArtifactsAggregator:
 
         request = SendMessageRequest(message=sample_message)
 
-        artifact_aggregator = ArtifactsAggregator.from_stream(
+        artifact_aggregator = ArtifactsAggregator(
             base_client.send_message(request)
         )
         artifact = await artifact_aggregator.get_artifact('artifact-1')
@@ -235,9 +235,7 @@ class TestArtifactsAggregator:
         mock_transport.send_message_streaming.return_value = create_stream()
 
         request = SendMessageRequest(message=sample_message)
-        aggregator = ArtifactsAggregator.from_stream(
-            base_client.send_message(request)
-        )
+        aggregator = ArtifactsAggregator(base_client.send_message(request))
         artifacts = await aggregator.get_all_artifacts()
 
         assert len(artifacts) == 2
@@ -284,9 +282,7 @@ class TestArtifactsAggregator:
         mock_transport.send_message_streaming.return_value = create_stream()
 
         request = SendMessageRequest(message=sample_message)
-        aggregator = ArtifactsAggregator.from_stream(
-            base_client.send_message(request)
-        )
+        aggregator = ArtifactsAggregator(base_client.send_message(request))
         artifacts = await aggregator.get_all_artifacts()
 
         assert len(artifacts) == 1
@@ -330,9 +326,7 @@ class TestArtifactsAggregator:
         mock_transport.send_message_streaming.return_value = create_stream()
 
         request = SendMessageRequest(message=sample_message)
-        aggregator = ArtifactsAggregator.from_stream(
-            base_client.send_message(request)
-        )
+        aggregator = ArtifactsAggregator(base_client.send_message(request))
         artifact = await aggregator.get_artifact('artifact-1')
 
         assert artifact is not None
@@ -367,9 +361,7 @@ class TestArtifactsAggregator:
         mock_transport.send_message_streaming.return_value = create_stream()
 
         request = SendMessageRequest(message=sample_message)
-        aggregator = ArtifactsAggregator.from_stream(
-            base_client.send_message(request)
-        )
+        aggregator = ArtifactsAggregator(base_client.send_message(request))
         artifact = await aggregator.get_artifact('artifact-1')
 
         assert artifact is None
@@ -414,7 +406,7 @@ class TestArtifactsAggregator:
 
         mock_transport.send_message_streaming.return_value = create_stream()
 
-        aggregator = ArtifactsAggregator.from_stream(
+        aggregator = ArtifactsAggregator(
             base_client.send_message(SendMessageRequest(message=sample_message))
         )
         artifacts = await aggregator.get_all_artifacts()
@@ -463,7 +455,7 @@ class TestArtifactsAggregator:
 
         mock_transport.send_message_streaming.return_value = create_stream()
 
-        aggregator = ArtifactsAggregator.from_stream(
+        aggregator = ArtifactsAggregator(
             base_client.send_message(SendMessageRequest(message=sample_message))
         )
         artifact = await aggregator.get_artifact('artifact-1')

--- a/tests/client/test_artifact_aggregator.py
+++ b/tests/client/test_artifact_aggregator.py
@@ -1,0 +1,474 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from a2a.client import BaseClient, ClientConfig
+from a2a.client.artifact_aggregator import ArtifactsAggregator
+from a2a.client.transports import ClientTransport
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    Artifact,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    StreamResponse,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+)
+
+
+@pytest.fixture
+def mock_transport() -> AsyncMock:
+    return AsyncMock(spec=ClientTransport)
+
+
+@pytest.fixture
+def sample_agent_card() -> AgentCard:
+    return AgentCard(
+        name='Test Agent',
+        description='An agent for testing',
+        supported_interfaces=[
+            AgentInterface(url='http://test.com', protocol_binding='HTTP+JSON')
+        ],
+        version='1.0',
+        capabilities=AgentCapabilities(streaming=True),
+        default_input_modes=['text/plain'],
+        default_output_modes=['text/plain'],
+        skills=[],
+    )
+
+
+@pytest.fixture
+def sample_message() -> Message:
+    return Message(
+        role=Role.ROLE_USER,
+        message_id='msg-1',
+        parts=[Part(text='Hello')],
+    )
+
+
+@pytest.fixture
+def base_client(
+    sample_agent_card: AgentCard, mock_transport: AsyncMock
+) -> BaseClient:
+    config = ClientConfig(streaming=True)
+    return BaseClient(
+        card=sample_agent_card,
+        config=config,
+        transport=mock_transport,
+        interceptors=[],
+    )
+
+
+class TestArtifactsAggregator:
+    @pytest.mark.asyncio
+    async def test_get_artifact_assembles_multiple_chunks(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_artifact correctly assembles an artifact from multiple chunks."""
+
+        async def create_stream(*args, **kwargs):
+            artifact_update_other = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-other',
+                    name='other',
+                    parts=[Part(text='ignored')],
+                ),
+                append=False,
+                last_chunk=True,
+            )
+            stream_response_other = StreamResponse()
+            stream_response_other.artifact_update.CopyFrom(
+                artifact_update_other
+            )
+            yield stream_response_other
+
+            artifact_update_chunk1 = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result',
+                    parts=[Part(text='Hello ')],
+                ),
+                append=False,
+                last_chunk=False,
+            )
+
+            artifact_update_chunk2 = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result',
+                    parts=[Part(text='World')],
+                ),
+                append=True,
+                last_chunk=True,
+            )
+
+            stream_response_1 = StreamResponse()
+            stream_response_1.artifact_update.CopyFrom(artifact_update_chunk1)
+
+            stream_response_2 = StreamResponse()
+            stream_response_2.artifact_update.CopyFrom(artifact_update_chunk2)
+
+            yield stream_response_1
+            yield stream_response_2
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        request = SendMessageRequest(message=sample_message)
+
+        artifact_aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(request)
+        )
+        artifact = await artifact_aggregator.get_artifact('artifact-1')
+
+        assert artifact is not None
+        assert artifact.artifact_id == 'artifact-1'
+        assert artifact.parts[0].text == 'Hello '
+        assert artifact.parts[1].text == 'World'
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_single_chunk(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_artifact correctly returns an artifact delivered in a single chunk."""
+
+        async def create_stream(*args, **kwargs):
+            artifact_update = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result',
+                    parts=[Part(text='Hello World')],
+                ),
+                append=False,
+                last_chunk=True,
+            )
+
+            stream_response = StreamResponse()
+            stream_response.artifact_update.CopyFrom(artifact_update)
+            yield stream_response
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        request = SendMessageRequest(message=sample_message)
+
+        artifact_aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(request)
+        )
+        artifact = await artifact_aggregator.get_artifact('artifact-1')
+
+        assert artifact is not None
+        assert artifact.artifact_id == 'artifact-1'
+        assert artifact.parts[0].text == 'Hello World'
+
+    @pytest.mark.asyncio
+    async def test_get_all_artifacts_assembles_multiple_artifacts(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_all_artifacts correctly assembles multiple artifacts from the stream."""
+
+        async def create_stream(*args, **kwargs):
+            artifact_update_1 = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result-1',
+                    parts=[Part(text='Hello ')],
+                ),
+                append=False,
+                last_chunk=False,
+            )
+            artifact_update_2 = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-2',
+                    name='result-2',
+                    parts=[Part(text='World')],
+                ),
+                append=False,
+                last_chunk=True,
+            )
+            artifact_update_3 = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result-1',
+                    parts=[Part(text='World')],
+                ),
+                append=True,
+                last_chunk=True,
+            )
+
+            for update in [
+                artifact_update_1,
+                artifact_update_2,
+                artifact_update_3,
+            ]:
+                sr = StreamResponse()
+                sr.artifact_update.CopyFrom(update)
+                yield sr
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        request = SendMessageRequest(message=sample_message)
+        aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(request)
+        )
+        artifacts = await aggregator.get_all_artifacts()
+
+        assert len(artifacts) == 2
+        artifact_map = {a.artifact_id: a for a in artifacts}
+
+        assert artifact_map['artifact-1'].parts[0].text == 'Hello '
+        assert artifact_map['artifact-1'].parts[1].text == 'World'
+        assert artifact_map['artifact-2'].parts[0].text == 'World'
+
+    @pytest.mark.asyncio
+    async def test_get_all_artifacts_skips_non_artifact_events(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_all_artifacts ignores non-artifact events in the stream."""
+
+        async def create_stream(*args, **kwargs):
+            task = Task(
+                id='task-123',
+                context_id='ctx-456',
+                status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+            )
+            sr_task = StreamResponse()
+            sr_task.task.CopyFrom(task)
+            yield sr_task
+
+            artifact_update = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result',
+                    parts=[Part(text='Hello')],
+                ),
+                append=False,
+                last_chunk=True,
+            )
+            sr_artifact = StreamResponse()
+            sr_artifact.artifact_update.CopyFrom(artifact_update)
+            yield sr_artifact
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        request = SendMessageRequest(message=sample_message)
+        aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(request)
+        )
+        artifacts = await aggregator.get_all_artifacts()
+
+        assert len(artifacts) == 1
+        assert artifacts[0].artifact_id == 'artifact-1'
+        assert artifacts[0].parts[0].text == 'Hello'
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_skips_non_artifact_events(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_artifact ignores non-artifact events in the stream."""
+
+        async def create_stream(*args, **kwargs):
+            task = Task(
+                id='task-123',
+                context_id='ctx-456',
+                status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+            )
+            sr_task = StreamResponse()
+            sr_task.task.CopyFrom(task)
+            yield sr_task
+
+            artifact_update = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-1',
+                    name='result',
+                    parts=[Part(text='Hello')],
+                ),
+                append=False,
+                last_chunk=True,
+            )
+            sr_artifact = StreamResponse()
+            sr_artifact.artifact_update.CopyFrom(artifact_update)
+            yield sr_artifact
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        request = SendMessageRequest(message=sample_message)
+        aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(request)
+        )
+        artifact = await aggregator.get_artifact('artifact-1')
+
+        assert artifact is not None
+        assert artifact.artifact_id == 'artifact-1'
+        assert artifact.parts[0].text == 'Hello'
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_returns_none_when_not_found(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_artifact returns None when the artifact_id is not found in the stream."""
+
+        async def create_stream(*args, **kwargs):
+            artifact_update = TaskArtifactUpdateEvent(
+                task_id='task-123',
+                context_id='ctx-456',
+                artifact=Artifact(
+                    artifact_id='artifact-other',
+                    name='result',
+                    parts=[Part(text='Hello')],
+                ),
+                append=False,
+                last_chunk=True,
+            )
+            stream_response = StreamResponse()
+            stream_response.artifact_update.CopyFrom(artifact_update)
+            yield stream_response
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        request = SendMessageRequest(message=sample_message)
+        aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(request)
+        )
+        artifact = await aggregator.get_artifact('artifact-1')
+
+        assert artifact is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_artifacts_resets_artifact_on_append_false(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_all_artifacts resets an artifact's parts when append=False is received."""
+
+        async def create_stream(*args, **kwargs):
+            for update in [
+                TaskArtifactUpdateEvent(
+                    task_id='task-123',
+                    context_id='ctx-456',
+                    artifact=Artifact(
+                        artifact_id='artifact-1',
+                        name='v1',
+                        parts=[Part(text='old')],
+                    ),
+                    append=False,
+                    last_chunk=False,
+                ),
+                TaskArtifactUpdateEvent(
+                    task_id='task-123',
+                    context_id='ctx-456',
+                    artifact=Artifact(
+                        artifact_id='artifact-1',
+                        name='v2',
+                        parts=[Part(text='new')],
+                    ),
+                    append=False,
+                    last_chunk=True,
+                ),
+            ]:
+                sr = StreamResponse()
+                sr.artifact_update.CopyFrom(update)
+                yield sr
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(SendMessageRequest(message=sample_message))
+        )
+        artifacts = await aggregator.get_all_artifacts()
+
+        assert len(artifacts) == 1
+        assert artifacts[0].parts[0].text == 'new'
+        assert artifacts[0].name == 'v2'
+
+    @pytest.mark.asyncio
+    async def test_get_artifact_resets_on_append_false(
+        self,
+        base_client: BaseClient,
+        mock_transport: AsyncMock,
+        sample_message: Message,
+    ) -> None:
+        """Test that get_artifact resets parts when append=False is received mid-stream."""
+
+        async def create_stream(*args, **kwargs):
+            for update in [
+                TaskArtifactUpdateEvent(
+                    task_id='task-123',
+                    context_id='ctx-456',
+                    artifact=Artifact(
+                        artifact_id='artifact-1',
+                        name='v1',
+                        parts=[Part(text='old')],
+                    ),
+                    append=False,
+                    last_chunk=False,
+                ),
+                TaskArtifactUpdateEvent(
+                    task_id='task-123',
+                    context_id='ctx-456',
+                    artifact=Artifact(
+                        artifact_id='artifact-1',
+                        name='v2',
+                        parts=[Part(text='new')],
+                    ),
+                    append=False,
+                    last_chunk=True,
+                ),
+            ]:
+                sr = StreamResponse()
+                sr.artifact_update.CopyFrom(update)
+                yield sr
+
+        mock_transport.send_message_streaming.return_value = create_stream()
+
+        aggregator = ArtifactsAggregator.from_stream(
+            base_client.send_message(SendMessageRequest(message=sample_message))
+        )
+        artifact = await aggregator.get_artifact('artifact-1')
+
+        assert artifact is not None
+        assert len(artifact.parts) == 1
+        assert artifact.parts[0].text == 'new'
+        assert artifact.name == 'v2'


### PR DESCRIPTION
## Description

  Adds `ArtifactsAggregator`, a client-side utility for reconstructing complete
  `Artifact` objects from a stream of `StreamResponse` events, as proposed in #734
  and tracked in #1030.

  The helper interprets the `append` and `last_chunk` flags of
  `TaskArtifactUpdateEvent` to correctly assemble chunked and interleaved artifacts
  without requiring changes to the existing client API.

  ### Usage

  ```python
  from a2a.client import ArtifactsAggregator

  # Assemble a single artifact by ID
  aggregator = ArtifactsAggregator.from_stream(client.send_message(request))
  artifact = await aggregator.get_artifact('my-artifact-id')

  # Assemble all artifacts
  aggregator = ArtifactsAggregator.from_stream(client.send_message(request))
  artifacts = await aggregator.get_all_artifacts()
  ```

  ### Changes
  
  - `src/a2a/client/artifact_aggregator.py` — new ArtifactsAggregator class
  - `src/a2a/client/__init__.py` — export ArtifactsAggregator
  - `docs/migrations/v1_0/README.md` — document usage under "Client: Send Message"
  - `tests/client/test_artifact_aggregator.py` — unit tests for all methods and edge cases

  Fixes #1030 🦕
