### PR TITLE
chore: pin types-protobuf to <7 to match protobuf constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ dev = [
   "respx>=0.20.2",
   "ruff>=0.12.8",
   "uv-dynamic-versioning>=0.8.2",
-  "types-protobuf",
+  "types-protobuf<7",
   "types-requests",
   "pre-commit",
   "trio",

--- a/uv.lock
+++ b/uv.lock
@@ -157,7 +157,7 @@ dev = [
     { name = "ruff", specifier = ">=0.12.8" },
     { name = "trio" },
     { name = "ty", specifier = ">=0.0.34" },
-    { name = "types-protobuf" },
+    { name = "types-protobuf", specifier = "<7" },
     { name = "types-requests" },
     { name = "uv-dynamic-versioning", specifier = ">=0.8.2" },
     { name = "uvicorn", specifier = ">=0.35.0" },


### PR DESCRIPTION
# Description
Pin `types-protobuf` to `<7` in the `dev` dependency group, mirroring the existing `protobuf>=5.29.5,<7` runtime constraint.
## Why
Dependabot keeps opening PRs (most recently #1046) that bump `types-protobuf` to 7.x. pulling in
the 7.x type stubs causes `ty` typechecking to fail in CI because of mismatch with `protobuf<7` constraint.

## Changes
- `pyproject.toml`: `"types-protobuf"` → `"types-protobuf<7"` in the `dev` dependency group.
- `uv.lock`: regenerated to record the new specifier (locked version unchanged — already on 6.32.1.x).