### PR TITLE
fix(compat): remove ListTasks from v0.3 REST adapter (#1043)

### DIFF
--- a/src/a2a/compat/v0_3/rest_adapter.py
+++ b/src/a2a/compat/v0_3/rest_adapter.py
@@ -142,9 +142,10 @@ class REST03Adapter:
             ): functools.partial(
                 self._handle_request, self.handler.list_push_notifications
             ),
-            ('/v1/tasks', 'GET'): functools.partial(
-                self._handle_request, self.handler.list_tasks
-            ),
+            # ListTasks is intentionally absent: not in the A2A v0.3 spec (see
+            # issue #1043). Sibling v0.3 transports (jsonrpc_transport,
+            # grpc_transport, rest_transport) also reject list_tasks with
+            # NotImplementedError — do not add a route here.
             ('/v1/card', 'GET'): functools.partial(
                 self._handle_request, self.handler.on_get_extended_agent_card
             ),

--- a/src/a2a/compat/v0_3/rest_handler.py
+++ b/src/a2a/compat/v0_3/rest_handler.py
@@ -291,15 +291,6 @@ class REST03Handler:
         return MessageToDict(pb2_v03_resp)
 
     @validate_version(constants.PROTOCOL_VERSION_0_3)
-    async def list_tasks(
-        self,
-        request: Request,
-        context: ServerCallContext,
-    ) -> dict[str, Any]:
-        """Handles the 'tasks/list' REST method."""
-        raise NotImplementedError('list tasks not implemented')
-
-    @validate_version(constants.PROTOCOL_VERSION_0_3)
     async def on_get_extended_agent_card(
         self,
         request: Request,

--- a/tests/compat/v0_3/test_rest_handler.py
+++ b/tests/compat/v0_3/test_rest_handler.py
@@ -357,12 +357,6 @@ async def test_list_push_notifications(
     assert called_req.params.id == 'task-1'
 
 
-@pytest.mark.anyio
-async def test_list_tasks(rest_handler, mock_request, mock_context):
-    with pytest.raises(NotImplementedError):
-        await rest_handler.list_tasks(mock_request, mock_context)
-
-
 # Add our new translation method test
 @pytest.mark.anyio
 async def test_on_get_extended_agent_card_success(

--- a/tests/compat/v0_3/test_rest_routes_compat.py
+++ b/tests/compat/v0_3/test_rest_routes_compat.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from a2a.compat.v0_3 import a2a_v0_3_pb2
+from a2a.compat.v0_3.rest_adapter import REST03Adapter
 from a2a.server.request_handlers.request_handler import RequestHandler
 from a2a.server.routes import create_agent_card_routes
 from a2a.server.routes.rest_routes import create_rest_routes
@@ -164,6 +165,14 @@ async def test_get_task_v03(
     actual_response = a2a_v0_3_pb2.Task()
     json_format.Parse(response.text, actual_response)
     assert expected_response == actual_response
+
+
+@pytest.mark.anyio
+async def test_list_tasks_not_in_v03_adapter_routes(
+    request_handler: RequestHandler,
+) -> None:
+    adapter = REST03Adapter(http_handler=request_handler)
+    assert ('/v1/tasks', 'GET') not in adapter.routes()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes #1043.

The A2A v0.3 spec does not define a `ListTasks` method, but `REST03Adapter` advertised `GET /v1/tasks` while `REST03Handler.list_tasks` raised `NotImplementedError` — exposing a route guaranteed to fail at runtime.

This PR aligns the v0.3 REST adapter with the rest of the v0.3 compat surface:
- **Removes** `('/v1/tasks', 'GET')` from `REST03Adapter.routes()`.
- **Removes** the dead `REST03Handler.list_tasks` stub.
- **Replaces** the stale `pytest.raises(NotImplementedError)` test with a regression test asserting the route is no longer registered in `REST03Adapter.routes()`.

This matches the design already present in the three sibling v0.3 transports — `jsonrpc_transport.py`, `grpc_transport.py`, and `rest_transport.py` — all of which explicitly raise `NotImplementedError('ListTasks is not supported in A2A v0.3 ...')`. (Confirmed with @ishymko in the issue thread to go with Option 2 from the report.)

## Known follow-up (out of scope)

With the route gone, `GET /v1/tasks` now falls through to the tenant catch-all (`Mount('/{tenant}', ...)` in `rest_routes.py`). A request with `A2A-Version: 0.3` will get a 400 version-mismatch error instead of a clean 404/405. This is a pre-existing routing quirk that affects any `/v1/<unknown>` path, not just `/v1/tasks` — worth a separate issue to tighten the tenant path converter or register an explicit 405 for reserved prefixes when v0.3 compat is enabled. Happy to follow up.

## Test plan

- [x] `uv run pytest tests/compat/v0_3/` — 249 passed
- [x] `./scripts/lint.sh` — ruff clean; `ty` reports only pre-existing errors in untouched lines (generated protobuf stubs)
- [x] Manual trace: `GET /v1/tasks` no longer routes to `REST03Handler.list_tasks`; the route is absent from `REST03Adapter.routes()`