### PR TITLE
ci(dependabot): pin types-protobuf to <v7 via ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       all:
         patterns:
           - '*'
+    ignore:
+      # Pin to v6.x. Dependabot rewrites pure upper-bound constraints in
+      # pyproject.toml (e.g. `<7` -> `<8`), so we must express this policy
+      # here instead.
+      # TODO: remove this ignore rule once the minimum
+      # protobuf version requirement is bumped.
+      - dependency-name: 'types-protobuf'
+        versions: ['>=7']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
# Description
Adds a dependabot `ignore` rule preventing `types-protobuf` from being bumped to `>=7` while the project's runtime `protobuf` is still pinned to `<7`.


Related: #1062, #1063