### PR TITLE
fix(telemetry): don't mark QueueShutDown as an error span

### DIFF
--- a/src/a2a/server/agent_execution/active_task.py
+++ b/src/a2a/server/agent_execution/active_task.py
@@ -59,7 +59,7 @@ from a2a.server.events.event_queue_v2 import (
     Event,
     EventQueueSource,
     QueueShutDown,
-    _create_async_queue,
+    create_async_queue,
 )
 from a2a.server.tasks import PushNotificationEvent
 from a2a.types.a2a_pb2 import (
@@ -402,7 +402,7 @@ class ActiveTask:
 
         # Queue for incoming requests
         self._request_queue: AsyncQueue[tuple[RequestContext, uuid.UUID]] = (
-            _create_async_queue()
+            create_async_queue()
         )
 
     @property

--- a/src/a2a/server/events/event_queue.py
+++ b/src/a2a/server/events/event_queue.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import sys
 import warnings
 
 from abc import ABC, abstractmethod
@@ -9,32 +8,16 @@ from typing import Any, cast
 
 from typing_extensions import Self
 
-
-if sys.version_info >= (3, 13):
-    from asyncio import Queue as AsyncQueue
-    from asyncio import QueueShutDown
-
-    def _create_async_queue(maxsize: int = 0) -> AsyncQueue[Any]:
-        """Create a backwards-compatible queue object."""
-        return AsyncQueue(maxsize=maxsize)
-else:
-    import culsans
-
-    from culsans import AsyncQueue  # type: ignore[no-redef]
-    from culsans import (
-        AsyncQueueShutDown as QueueShutDown,  # type: ignore[no-redef]
-    )
-
-    def _create_async_queue(maxsize: int = 0) -> AsyncQueue[Any]:
-        """Create a backwards-compatible queue object."""
-        return culsans.Queue(maxsize=maxsize).async_q  # type: ignore[no-any-return]
-
-
 from a2a.types.a2a_pb2 import (
     Message,
     Task,
     TaskArtifactUpdateEvent,
     TaskStatusUpdateEvent,
+)
+from a2a.utils._async_queue_compat import (
+    AsyncQueue,
+    QueueShutDown,
+    create_async_queue,
 )
 from a2a.utils.telemetry import SpanKind, trace_class
 
@@ -101,7 +84,7 @@ class EventQueueLegacy(EventQueue):
         if max_queue_size <= 0:
             raise ValueError('max_queue_size must be greater than 0')
 
-        self._queue: AsyncQueue[Event] = _create_async_queue(
+        self._queue: AsyncQueue[Event] = create_async_queue(
             maxsize=max_queue_size
         )
         self._children: list[EventQueueLegacy] = []

--- a/src/a2a/server/events/event_queue_v2.py
+++ b/src/a2a/server/events/event_queue_v2.py
@@ -12,7 +12,7 @@ from a2a.server.events.event_queue import (
     Event,
     EventQueue,
     QueueShutDown,
-    _create_async_queue,
+    create_async_queue,
 )
 from a2a.utils.telemetry import SpanKind, trace_class
 
@@ -37,7 +37,7 @@ class EventQueueSource(EventQueue):
         if max_queue_size <= 0:
             raise ValueError('max_queue_size must be greater than 0')
 
-        self._incoming_queue: AsyncQueue[Event] = _create_async_queue(
+        self._incoming_queue: AsyncQueue[Event] = create_async_queue(
             maxsize=max_queue_size
         )
         self._lock = asyncio.Lock()
@@ -293,7 +293,7 @@ class EventQueueSink(EventQueue):
             raise ValueError('max_queue_size must be greater than 0')
 
         self._parent = parent
-        self._queue: AsyncQueue[Event] = _create_async_queue(
+        self._queue: AsyncQueue[Event] = create_async_queue(
             maxsize=max_queue_size
         )
         self._is_closed = False

--- a/src/a2a/utils/_async_queue_compat.py
+++ b/src/a2a/utils/_async_queue_compat.py
@@ -1,0 +1,28 @@
+"""Cross-version aliases for async queue primitives."""
+
+import sys
+
+from typing import Any
+
+
+if sys.version_info >= (3, 13):
+    from asyncio import Queue as AsyncQueue
+    from asyncio import QueueShutDown
+
+    def create_async_queue(maxsize: int = 0) -> AsyncQueue[Any]:
+        """Create a backwards-compatible async queue object."""
+        return AsyncQueue(maxsize=maxsize)
+else:
+    import culsans
+
+    from culsans import AsyncQueue  # type: ignore[no-redef]
+    from culsans import (
+        AsyncQueueShutDown as QueueShutDown,  # type: ignore[no-redef]
+    )
+
+    def create_async_queue(maxsize: int = 0) -> AsyncQueue[Any]:
+        """Create a backwards-compatible async queue object."""
+        return culsans.Queue(maxsize=maxsize).async_q  # type: ignore[no-any-return]
+
+
+__all__ = ['AsyncQueue', 'QueueShutDown', 'create_async_queue']

--- a/src/a2a/utils/telemetry.py
+++ b/src/a2a/utils/telemetry.py
@@ -68,12 +68,13 @@ import functools
 import inspect
 import logging
 import os
-import sys
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self
+
+from a2a.utils._async_queue_compat import QueueShutDown
 
 
 if TYPE_CHECKING:
@@ -145,14 +146,9 @@ SpanKind = _SpanKind
 __all__ = ['SpanKind']
 
 
-if sys.version_info >= (3, 13):
-    from asyncio import QueueShutDown as _QueueShutDown
-else:
-    from culsans import AsyncQueueShutDown as _QueueShutDown
-
-_GRACEFUL_ASYNC_EXCEPTIONS: tuple[type[BaseException], ...] = (
+_NON_ERROR_EXCEPTIONS: tuple[type[BaseException], ...] = (
     asyncio.CancelledError,
-    _QueueShutDown,
+    QueueShutDown,
 )
 
 
@@ -245,9 +241,7 @@ def trace_function(  # noqa: PLR0915
                 # Async wrapper, await for the function call to complete.
                 result = await func(*args, **kwargs)
                 span.set_status(StatusCode.OK)
-            # Graceful end-of-operation signals (currently asyncio.CancelledError,
-            # QueueShutDown).
-            except _GRACEFUL_ASYNC_EXCEPTIONS as ge:
+            except _NON_ERROR_EXCEPTIONS as ge:
                 exception = None
                 logger.debug(
                     '%s in span %s',

--- a/src/a2a/utils/telemetry.py
+++ b/src/a2a/utils/telemetry.py
@@ -68,6 +68,7 @@ import functools
 import inspect
 import logging
 import os
+import sys
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -142,6 +143,17 @@ if not otel_installed or not otel_enabled:
 
 SpanKind = _SpanKind
 __all__ = ['SpanKind']
+
+
+if sys.version_info >= (3, 13):
+    from asyncio import QueueShutDown as _QueueShutDown
+else:
+    from culsans import AsyncQueueShutDown as _QueueShutDown
+
+_GRACEFUL_ASYNC_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    asyncio.CancelledError,
+    _QueueShutDown,
+)
 
 
 def trace_function(  # noqa: PLR0915
@@ -233,11 +245,16 @@ def trace_function(  # noqa: PLR0915
                 # Async wrapper, await for the function call to complete.
                 result = await func(*args, **kwargs)
                 span.set_status(StatusCode.OK)
-            # asyncio.CancelledError extends from BaseException
-            except asyncio.CancelledError as ce:
+            # Graceful end-of-operation signals (currently asyncio.CancelledError,
+            # QueueShutDown).
+            except _GRACEFUL_ASYNC_EXCEPTIONS as ge:
                 exception = None
-                logger.debug('CancelledError in span %s', actual_span_name)
-                span.record_exception(ce)
+                logger.debug(
+                    '%s in span %s',
+                    type(ge).__name__,
+                    actual_span_name,
+                )
+                span.record_exception(ge)
                 raise
             except Exception as e:
                 exception = e

--- a/tests/utils/test_telemetry.py
+++ b/tests/utils/test_telemetry.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from a2a.server.events.event_queue import QueueShutDown
 from a2a.utils.telemetry import trace_class, trace_function
 
 
@@ -268,19 +269,8 @@ def test_env_var_disabled_logs_message(
     assert 'OTEL_INSTRUMENTATION_A2A_SDK_ENABLED' in caplog.text
 
 
-def _graceful_async_exceptions() -> list[type[BaseException]]:
-    """Exception classes the async wrapper must treat as graceful.
-
-    Imported lazily so the module-level collection isn't evaluated until the
-    test runs (keeps import-time side effects out of unrelated tests).
-    """
-    from a2a.server.events.event_queue import QueueShutDown
-
-    return [asyncio.CancelledError, QueueShutDown]
-
-
 @pytest.mark.asyncio
-@pytest.mark.parametrize('exc_cls', _graceful_async_exceptions())
+@pytest.mark.parametrize('exc_cls', [asyncio.CancelledError, QueueShutDown])
 async def test_trace_function_async_graceful_exception_does_not_mark_span_error(
     mock_span: mock.MagicMock,
     exc_cls: type[BaseException],

--- a/tests/utils/test_telemetry.py
+++ b/tests/utils/test_telemetry.py
@@ -266,3 +266,41 @@ def test_env_var_disabled_logs_message(
         in caplog.text
     )
     assert 'OTEL_INSTRUMENTATION_A2A_SDK_ENABLED' in caplog.text
+
+
+def _graceful_async_exceptions() -> list[type[BaseException]]:
+    """Exception classes the async wrapper must treat as graceful.
+
+    Imported lazily so the module-level collection isn't evaluated until the
+    test runs (keeps import-time side effects out of unrelated tests).
+    """
+    from a2a.server.events.event_queue import QueueShutDown
+
+    return [asyncio.CancelledError, QueueShutDown]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('exc_cls', _graceful_async_exceptions())
+async def test_trace_function_async_graceful_exception_does_not_mark_span_error(
+    mock_span: mock.MagicMock,
+    exc_cls: type[BaseException],
+) -> None:
+    """`trace_function` records graceful exceptions but never marks span ERROR.
+
+    Covers `asyncio.CancelledError` and `QueueShutDown`.
+    """
+
+    @trace_function
+    async def graceful() -> NoReturn:
+        await asyncio.sleep(0)
+        raise exc_cls('graceful end-of-operation')
+
+    with pytest.raises(exc_cls):
+        await graceful()
+
+    mock_span.record_exception.assert_called()
+    # The wrapper only passes `description=` when calling
+    # `set_status(StatusCode.ERROR, ...)`. Its absence on every call proves
+    # the span was never marked as failed.
+    for call in mock_span.set_status.call_args_list:
+        assert 'description' not in call.kwargs

--- a/tests/utils/test_telemetry.py
+++ b/tests/utils/test_telemetry.py
@@ -271,22 +271,22 @@ def test_env_var_disabled_logs_message(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('exc_cls', [asyncio.CancelledError, QueueShutDown])
-async def test_trace_function_async_graceful_exception_does_not_mark_span_error(
+async def test_trace_function_async_non_error_exception_does_not_mark_span_error(
     mock_span: mock.MagicMock,
     exc_cls: type[BaseException],
 ) -> None:
-    """`trace_function` records graceful exceptions but never marks span ERROR.
+    """`trace_function` records non-error exceptions but never marks span ERROR.
 
     Covers `asyncio.CancelledError` and `QueueShutDown`.
     """
 
     @trace_function
-    async def graceful() -> NoReturn:
+    async def non_error_exception() -> NoReturn:
         await asyncio.sleep(0)
-        raise exc_cls('graceful end-of-operation')
+        raise exc_cls('operation ended with non-error exception')
 
     with pytest.raises(exc_cls):
-        await graceful()
+        await non_error_exception()
 
     mock_span.record_exception.assert_called()
     # The wrapper only passes `description=` when calling


### PR DESCRIPTION
# Description
## Summary
`trace_function`'s async wrapper marks any exception other than `CancelledError` as `StatusCode.ERROR`. This wrongly flags `QueueShutDown`, the normal signal raised when a producer cleanly closes an event queue, as a failure.
## Change
- Add `QueueShutDown` to the same graceful-exception allowlist as`CancelledError` in `src/a2a/utils/telemetry.py`. The class is resolved per Python version (stdlib on 3.13+, `culsans` back-port on <3.13), mirroring `event_queue.py`.
- Add parametrized a test covering both `CancelledError` and `QueueShutDown`.

Fixes #1065🦕
