### PR TITLE
fix(telemetry): add QueueShutDown to graceful-exception allowlist (#1065)

### DIFF
--- a/src/a2a/utils/telemetry.py
+++ b/src/a2a/utils/telemetry.py
@@ -68,11 +68,32 @@ import functools
 import inspect
 import logging
 import os
+import sys
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self
+
+# Graceful-shutdown exception allowlist. ``asyncio.CancelledError`` is always
+# treated as non-error.  On Python 3.13+ ``asyncio.QueueShutDown`` is also
+# a graceful signal; on older versions the back-port ``culsans`` exposes it
+# as ``AsyncQueueShutDown``.  Import whichever is available.
+_GRACEFUL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    asyncio.CancelledError,
+)
+if sys.version_info >= (3, 13):
+    _GRACEFUL_EXCEPTIONS = (
+        asyncio.CancelledError,
+        asyncio.QueueShutDown,  # type: ignore[attr-defined]
+    )
+else:
+    try:
+        from culsans import AsyncQueueShutDown
+
+        _GRACEFUL_EXCEPTIONS = (asyncio.CancelledError, AsyncQueueShutDown)
+    except ImportError:
+        pass  # culsans not installed — fall back to CancelledError only
 
 
 if TYPE_CHECKING:
@@ -233,11 +254,14 @@ def trace_function(  # noqa: PLR0915
                 # Async wrapper, await for the function call to complete.
                 result = await func(*args, **kwargs)
                 span.set_status(StatusCode.OK)
-            # asyncio.CancelledError extends from BaseException
-            except asyncio.CancelledError as ce:
+            # Graceful-shutdown exceptions — record but do NOT mark as ERROR.
+            # ``asyncio.CancelledError`` is always included; on Python 3.13+
+            # ``asyncio.QueueShutDown`` (or the culsans back-port) is added
+            # when the queue is closed normally.
+            except _GRACEFUL_EXCEPTIONS as ge:
                 exception = None
-                logger.debug('CancelledError in span %s', actual_span_name)
-                span.record_exception(ce)
+                logger.debug('%s in span %s', type(ge).__name__, actual_span_name)
+                span.record_exception(ge)
                 raise
             except Exception as e:
                 exception = e

--- a/src/a2a/utils/telemetry.py
+++ b/src/a2a/utils/telemetry.py
@@ -79,19 +79,14 @@ from typing_extensions import Self
 # treated as non-error.  On Python 3.13+ ``asyncio.QueueShutDown`` is also
 # a graceful signal; on older versions the back-port ``culsans`` exposes it
 # as ``AsyncQueueShutDown``.  Import whichever is available.
-_GRACEFUL_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    asyncio.CancelledError,
-)
+_GRACEFUL_EXCEPTIONS: tuple[type[BaseException], ...] = (asyncio.CancelledError,)
 if sys.version_info >= (3, 13):
-    _GRACEFUL_EXCEPTIONS = (
-        asyncio.CancelledError,
-        asyncio.QueueShutDown,  # type: ignore[attr-defined]
-    )
+    _GRACEFUL_EXCEPTIONS += (asyncio.QueueShutDown,)  # type: ignore[attr-defined]
 else:
     try:
         from culsans import AsyncQueueShutDown
 
-        _GRACEFUL_EXCEPTIONS = (asyncio.CancelledError, AsyncQueueShutDown)
+        _GRACEFUL_EXCEPTIONS += (AsyncQueueShutDown,)
     except ImportError:
         pass  # culsans not installed — fall back to CancelledError only
 

--- a/tests/utils/test_telemetry.py
+++ b/tests/utils/test_telemetry.py
@@ -266,3 +266,65 @@ def test_env_var_disabled_logs_message(
         in caplog.text
     )
     assert 'OTEL_INSTRUMENTATION_A2A_SDK_ENABLED' in caplog.text
+
+
+# ─── Graceful-shutdown exception allowlist ───────────────────────────────
+
+
+class _FakeQueueShutDown(BaseException):
+    """Simulated graceful-shutdown exception matching QueueShutDown semantics."""
+
+
+@pytest.mark.asyncio
+async def test_trace_function_async_cancelled_error_graceful(
+    mock_span: mock.MagicMock,
+) -> None:
+    """CancelledError is recorded but does NOT set span status to ERROR."""
+
+    @trace_function
+    async def raises_cancelled() -> NoReturn:
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await raises_cancelled()
+
+    mock_span.record_exception.assert_called()
+    # Should NOT have set ERROR status
+    for call in mock_span.set_status.call_args_list:
+        args, _ = call
+        if args and hasattr(args[0], 'name'):
+            assert args[0].name != 'ERROR', (
+                'CancelledError should not set ERROR status'
+            )
+
+
+@pytest.mark.asyncio
+async def test_trace_function_async_queue_shutdown_graceful(
+    mock_span: mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QueueShutDown (or back-port) is recorded but does NOT set ERROR status."""
+    from a2a.utils import telemetry
+
+    # Patch the graceful-exceptions tuple to include our fake exception
+    monkeypatch.setattr(
+        telemetry,
+        '_GRACEFUL_EXCEPTIONS',
+        (asyncio.CancelledError, _FakeQueueShutDown),
+    )
+
+    @trace_function
+    async def raises_shutdown() -> NoReturn:
+        raise _FakeQueueShutDown('queue closed')
+
+    with pytest.raises(_FakeQueueShutDown):
+        await raises_shutdown()
+
+    mock_span.record_exception.assert_called()
+    # Should NOT have set ERROR status
+    for call in mock_span.set_status.call_args_list:
+        args, _ = call
+        if args and hasattr(args[0], 'name'):
+            assert args[0].name != 'ERROR', (
+                'QueueShutDown should not set ERROR status'
+            )


### PR DESCRIPTION
## What broke
`trace_function`'s async wrapper in `src/a2a/utils/telemetry.py` special-cases `asyncio.CancelledError` — recording the exception but NOT marking the span as ERROR. However, `asyncio.QueueShutDown` (and the `culsans.AsyncQueueShutDown` back-port) is raised as a normal graceful shutdown signal by `EventQueue` and `EventQueueSource`, but was caught by the generic `Exception` handler. This causes spurious ERROR spans and `StatusCode.ERROR` status on every normal task completion, polluting telemetry dashboards with false positives.

## Root cause
The `except asyncio.CancelledError` block only covers `CancelledError`. When `dequeue_event()` raises `QueueShutDown` during normal queue shutdown, it falls through to the `except Exception` block which records it as an error.

## Why this fix is minimal
Extends the existing graceful-exception tuple (`_GRACEFUL_EXCEPTIONS`) to include `QueueShutDown`. On Python 3.13+ `asyncio.QueueShutDown` is used; on older versions the `culsans.AsyncQueueShutDown` back-port is added when available. No changes to sync wrapper (QueueShutDown is only raised in async paths). No changes to span naming, attribute extraction, or any other telemetry behavior.

## What I tested
Added two new async tests in `tests/utils/test_telemetry.py`:
- `test_trace_function_async_cancelled_error_graceful` — verifies CancelledError does NOT set ERROR status
- `test_trace_function_async_queue_shutdown_graceful` — verifies QueueShutDown does NOT set ERROR status (via monkeypatch)

Existing tests remain unchanged.

## What I intentionally did not change
- Sync wrapper (QueueShutDown is only raised in async paths)
- Any other telemetry functions (trace_class, etc.)
- Exception recording behavior (exception is still recorded, just not marked as ERROR)