### PR TITLE
fix: properly convert metadata to dict in `RequestContext.metadata`

### DIFF
--- a/src/a2a/server/agent_execution/context.py
+++ b/src/a2a/server/agent_execution/context.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from google.protobuf import json_format
+
 from a2a.helpers.proto_helpers import get_message_text
 from a2a.server.context import ServerCallContext
 from a2a.server.id_generator import (
@@ -148,7 +150,10 @@ class RequestContext:
     def metadata(self) -> dict[str, Any]:
         """Metadata associated with the request, if available."""
         if self._params and self._params.metadata:
-            return dict(self._params.metadata)
+            # metadata is a google.protobuf.Struct,
+            # MessageToDict recurses into nested Struct/ListValue fields;
+            # dict would leak raw protobuf objects to callers.
+            return json_format.MessageToDict(self._params.metadata)
         return {}
 
     @property

--- a/src/a2a/server/agent_execution/context.py
+++ b/src/a2a/server/agent_execution/context.py
@@ -149,8 +149,7 @@ class RequestContext:
     @property
     def metadata(self) -> dict[str, Any]:
         """Metadata associated with the request, if available."""
-        if self._params and self._params.metadata:
-            # metadata is a google.protobuf.Struct,
+        if self._params:
             # MessageToDict recurses into nested Struct/ListValue fields;
             # dict would leak raw protobuf objects to callers.
             return json_format.MessageToDict(self._params.metadata)

--- a/tests/server/agent_execution/test_context.py
+++ b/tests/server/agent_execution/test_context.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 from unittest.mock import Mock, patch
@@ -13,6 +14,7 @@ from a2a.types.a2a_pb2 import (
     Task,
 )
 from a2a.utils.errors import InvalidParamsError
+from google.protobuf import struct_pb2
 
 
 class TestRequestContext:
@@ -270,9 +272,26 @@ class TestRequestContext:
 
     def test_metadata_property_with_content(self, mock_params: Mock) -> None:
         """Test metadata property returns the metadata from params."""
-        mock_params.metadata = {'key': 'value'}
+        struct = struct_pb2.Struct()
+        struct['key'] = 'value'
+        mock_params.metadata = struct
         context = RequestContext(ServerCallContext(), request=mock_params)
         assert context.metadata == {'key': 'value'}
+
+    def test_metadata_property_with_real_struct_nested(self) -> None:
+        """Regression: `dict(struct)` leaves nested Struct/ListValue as raw
+        protobuf objects, breaking JSON serialization of the returned dict.
+        """
+        request = SendMessageRequest()
+        request.metadata['flat_str'] = 'value1'
+        request.metadata['nested'] = {'a': 1, 'b': [1, 2, 3]}
+
+        md = RequestContext(ServerCallContext(), request=request).metadata
+
+        assert json.loads(json.dumps(md)) == {
+            'flat_str': 'value1',
+            'nested': {'a': 1.0, 'b': [1.0, 2.0, 3.0]},
+        }
 
     def test_init_with_existing_ids_in_message(
         self, mock_message: Mock, mock_params: Mock


### PR DESCRIPTION
A leftover from Pydantic -> protobuf migration.
