### PR TITLE
fix: distinguish graceful EventQueue shutdown

### DIFF
--- a/src/a2a/server/events/event_queue_v2.py
+++ b/src/a2a/server/events/event_queue_v2.py
@@ -20,6 +20,10 @@ from a2a.utils.telemetry import SpanKind, trace_class
 logger = logging.getLogger(__name__)
 
 
+class QueueShutDownNormal(QueueShutDown):
+    """Raised when a sink is closed by a graceful queue shutdown."""
+
+
 @trace_class(kind=SpanKind.SERVER)
 class EventQueueSource(EventQueue):
     """The Parent EventQueue.
@@ -297,6 +301,7 @@ class EventQueueSink(EventQueue):
             maxsize=max_queue_size
         )
         self._is_closed = False
+        self._closed_immediate: bool | None = None
         self._lock = asyncio.Lock()
 
         logger.debug('EventQueueSink initialized.')
@@ -317,7 +322,14 @@ class EventQueueSink(EventQueue):
     async def dequeue_event(self) -> Event:
         """Pulls an event from the sink queue."""
         logger.debug('Attempting to dequeue event (waiting).')
-        event = await self._queue.get()
+        try:
+            event = await self._queue.get()
+        except QueueShutDown as exc:
+            if self._is_closed and self._closed_immediate is False:
+                raise QueueShutDownNormal(
+                    'Queue closed after graceful shutdown.'
+                ) from exc
+            raise
         logger.debug('Dequeued event: %s', event)
         return event
 
@@ -347,6 +359,7 @@ class EventQueueSink(EventQueue):
         logger.debug('Closing EventQueueSink.')
         async with self._lock:
             self._is_closed = True
+            self._closed_immediate = immediate
             self._queue.shutdown(immediate=immediate)
 
         # Ignore KeyError (close have to be idempotent).

--- a/tests/server/events/test_event_queue_v2.py
+++ b/tests/server/events/test_event_queue_v2.py
@@ -14,6 +14,7 @@ from a2a.server.events.event_queue import (
 from a2a.server.events.event_queue_v2 import (
     EventQueueSink,
     EventQueueSource,
+    QueueShutDownNormal,
 )
 from a2a.server.jsonrpc_models import JSONRPCError
 from a2a.types import (
@@ -231,14 +232,14 @@ async def test_dequeue_event_closed_and_empty(
     event_queue: EventQueueSource,
     expected_queue_closed_exception: type[Exception],
 ) -> None:
-    """Test dequeue_event raises QueueShutDown when closed and empty."""
+    """Test dequeue_event raises normal shutdown when gracefully closed."""
     await event_queue.close()
     assert event_queue.is_closed()
     # Ensure queue is actually empty (e.g. by trying a non-blocking get on internal queue)
     with pytest.raises(expected_queue_closed_exception):
         event_queue.queue.get_nowait()
 
-    with pytest.raises(expected_queue_closed_exception):
+    with pytest.raises(QueueShutDownNormal):
         await event_queue.dequeue_event()
 
 
@@ -377,7 +378,7 @@ async def test_event_queue_dequeue_immediate_false(
     await close_task
 
     # Queue is now empty and closed
-    with pytest.raises(QueueShutDown):
+    with pytest.raises(QueueShutDownNormal):
         await event_queue.dequeue_event()
 
 
@@ -389,8 +390,9 @@ async def test_event_queue_dequeue_immediate_true(
     await event_queue.enqueue_event(msg)
     await event_queue.close(immediate=True)
     # The queue is immediately flushed, so dequeue should raise QueueShutDown
-    with pytest.raises(QueueShutDown):
+    with pytest.raises(QueueShutDown) as exc_info:
         await event_queue.dequeue_event()
+    assert not isinstance(exc_info.value, QueueShutDownNormal)
 
 
 @pytest.mark.asyncio
@@ -401,8 +403,9 @@ async def test_event_queue_enqueue_when_closed(
     msg = create_sample_message()
     await event_queue.enqueue_event(msg)
     # Enqueue should have returned without doing anything
-    with pytest.raises(QueueShutDown):
+    with pytest.raises(QueueShutDown) as exc_info:
         await event_queue.dequeue_event()
+    assert not isinstance(exc_info.value, QueueShutDownNormal)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add QueueShutDownNormal for graceful EventQueueSink shutdowns
- map graceful sink dequeue shutdowns to the narrower subclass
- keep immediate shutdown and closed enqueue/tap paths on the generic QueueShutDown signal

## Motivation
The v2 queue currently uses the same QueueShutDown class for graceful stream teardown and abnormal lifecycle paths such as immediate close or attempts to use a closed queue. Telemetry wrappers and consumers cannot distinguish those cases after the generic exception is raised.

## Validation
- UV_CACHE_DIR=/var/tmp/argylle/tmp/task-1779877269025068489-2f550c95/uv-cache UV_PYTHON_INSTALL_DIR=/var/tmp/argylle/tmp/task-1779877269025068489-2f550c95/uv-python uv run pytest tests/server/events/test_event_queue_v2.py -q