### PR TITLE
ci: add `question` label to `stale.yaml`

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -27,7 +27,7 @@ jobs:
           days-before-issue-close: 13
           stale-issue-label: "status:stale"
           close-issue-reason: not_planned
-          any-of-labels: "status:awaiting response,status:more data needed"
+          any-of-labels: "status:awaiting response,status:more data needed,question"
           stale-issue-message: >
             Marking this issue as stale since it has been open for 14 days with no activity.
             This issue will be closed if no further activity occurs.


### PR DESCRIPTION
Given that it's include list adding `question` label which has some adoption in this repo.

Currently although the [workflow runs](https://github.com/a2aproject/a2a-python/actions/workflows/stale.yaml) existing labels are not used so it does not mark any issues as stale.