### PR TITLE
feat: add `fastapi` optional dependency extra

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -28,6 +28,8 @@ jobs:
             extras: ''
           - name: http-server
             extras: '[http-server]'
+          - name: fastapi
+            extras: '[fastapi]'
           - name: grpc
             extras: '[grpc]'
           - name: telemetry

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Install the core SDK and any desired extras using your preferred package manager
 | **Core SDK**             | `uv add a2a-sdk`                           | `pip install a2a-sdk`                        |
 | **All Extras**           | `uv add "a2a-sdk[all]"`                    | `pip install "a2a-sdk[all]"`                 |
 | **HTTP Server**          | `uv add "a2a-sdk[http-server]"`            | `pip install "a2a-sdk[http-server]"`         |
-| **FastAPI**              | `uv add "a2a-sdk[fastapi]"`                | `pip install "a2a-sdk[fastapi]"`             |
+| **FastAPI Integration**  | `uv add "a2a-sdk[fastapi]"`                | `pip install "a2a-sdk[fastapi]"`             |
 | **gRPC Support**         | `uv add "a2a-sdk[grpc]"`                   | `pip install "a2a-sdk[grpc]"`                |
 | **OpenTelemetry Tracing**| `uv add "a2a-sdk[telemetry]"`              | `pip install "a2a-sdk[telemetry]"`           |
 | **Encryption**           | `uv add "a2a-sdk[encryption]"`             | `pip install "a2a-sdk[encryption]"`          |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Install the core SDK and any desired extras using your preferred package manager
 | **Core SDK**             | `uv add a2a-sdk`                           | `pip install a2a-sdk`                        |
 | **All Extras**           | `uv add "a2a-sdk[all]"`                    | `pip install "a2a-sdk[all]"`                 |
 | **HTTP Server**          | `uv add "a2a-sdk[http-server]"`            | `pip install "a2a-sdk[http-server]"`         |
+| **FastAPI**              | `uv add "a2a-sdk[fastapi]"`                | `pip install "a2a-sdk[fastapi]"`             |
 | **gRPC Support**         | `uv add "a2a-sdk[grpc]"`                   | `pip install "a2a-sdk[grpc]"`                |
 | **OpenTelemetry Tracing**| `uv add "a2a-sdk[telemetry]"`              | `pip install "a2a-sdk[telemetry]"`           |
 | **Encryption**           | `uv add "a2a-sdk[encryption]"`             | `pip install "a2a-sdk[encryption]"`          |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 
 [project.optional-dependencies]
 http-server = ["sse-starlette", "starlette"]
+fastapi = ["a2a-sdk[http-server]", "fastapi>=0.115.2"]
 encryption = ["cryptography>=43.0.0"]
 grpc = ["grpcio>=1.60", "grpcio-tools>=1.60", "grpcio-status>=1.60", "grpcio_reflection>=1.7.0"]
 telemetry = ["opentelemetry-api>=1.33.0", "opentelemetry-sdk>=1.33.0"]
@@ -48,6 +49,7 @@ sql = ["a2a-sdk[postgresql,mysql,sqlite]"]
 
 all = [
   "a2a-sdk[http-server]",
+  "a2a-sdk[fastapi]",
   "a2a-sdk[sql]",
   "a2a-sdk[encryption]",
   "a2a-sdk[grpc]",

--- a/scripts/test_install_smoke.sh
+++ b/scripts/test_install_smoke.sh
@@ -9,6 +9,7 @@
 # Available profiles (must match those in tests/install_smoke/__main__.py):
 #   base         -- `pip install a2a-sdk`
 #   http-server  -- `pip install a2a-sdk[http-server]`
+#   fastapi      -- `pip install a2a-sdk[fastapi]`
 #   grpc         -- `pip install a2a-sdk[grpc]`
 #   telemetry    -- `pip install a2a-sdk[telemetry]`
 #   sql          -- `pip install a2a-sdk[sql]`
@@ -27,7 +28,7 @@ set -o pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-ALL_PROFILES=(base http-server grpc telemetry sql)
+ALL_PROFILES=(base http-server fastapi grpc telemetry sql)
 
 PROFILE_ARG="${1:-}"
 PYTHON_VERSION="${2:-}"
@@ -42,6 +43,7 @@ extras_for_profile() {
     case "$1" in
         base)        echo "" ;;
         http-server) echo "[http-server]" ;;
+        fastapi)     echo "[fastapi]" ;;
         grpc)        echo "[grpc]" ;;
         telemetry)   echo "[telemetry]" ;;
         sql)         echo "[sql]" ;;

--- a/src/a2a/server/routes/fastapi_routes.py
+++ b/src/a2a/server/routes/fastapi_routes.py
@@ -135,8 +135,8 @@ def add_a2a_routes_to_fastapi(
     if not _package_fastapi_installed:
         raise ImportError(
             'The `fastapi` package is required to use '
-            '`add_a2a_routes_to_fastapi`. It can be installed as part of '
-            '`a2a-sdk` optional dependencies, `a2a-sdk[fastapi]`.'
+            '`add_a2a_routes_to_fastapi`. Install it via '
+            '`a2a-sdk[fastapi]`.'
         )
 
     components: dict[str, Any] = {}

--- a/src/a2a/server/routes/fastapi_routes.py
+++ b/src/a2a/server/routes/fastapi_routes.py
@@ -135,8 +135,8 @@ def add_a2a_routes_to_fastapi(
     if not _package_fastapi_installed:
         raise ImportError(
             'The `fastapi` package is required to use '
-            '`add_a2a_routes_to_fastapi`. Install it alongside '
-            '`a2a-sdk[http-server]`.'
+            '`add_a2a_routes_to_fastapi`. It can be installed as part of '
+            '`a2a-sdk` optional dependencies, `a2a-sdk[fastapi]`.'
         )
 
     components: dict[str, Any] = {}

--- a/tests/install_smoke/__main__.py
+++ b/tests/install_smoke/__main__.py
@@ -49,6 +49,10 @@ HTTP_SERVER_MODULES = [
     'a2a.server.routes.rest_routes',
 ]
 
+FASTAPI_MODULES = [
+    'a2a.server.routes.fastapi_routes',
+]
+
 GRPC_MODULES = [
     'a2a.server.request_handlers.grpc_handler',
     'a2a.client.transports.grpc',
@@ -70,6 +74,7 @@ SQL_MODULES = [
 PROFILES: dict[str, list[str]] = {
     'base': CORE_MODULES,
     'http-server': CORE_MODULES + HTTP_SERVER_MODULES,
+    'fastapi': CORE_MODULES + HTTP_SERVER_MODULES + FASTAPI_MODULES,
     'grpc': CORE_MODULES + GRPC_MODULES,
     'telemetry': CORE_MODULES + TELEMETRY_MODULES,
     'sql': CORE_MODULES + SQL_MODULES,

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dependencies = [
 all = [
     { name = "alembic" },
     { name = "cryptography" },
+    { name = "fastapi" },
     { name = "grpcio" },
     { name = "grpcio-reflection" },
     { name = "grpcio-status" },
@@ -43,6 +44,11 @@ db-cli = [
 ]
 encryption = [
     { name = "cryptography" },
+]
+fastapi = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
 ]
 grpc = [
     { name = "grpcio" },
@@ -103,6 +109,8 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'all'", specifier = ">=43.0.0" },
     { name = "cryptography", marker = "extra == 'encryption'", specifier = ">=43.0.0" },
     { name = "culsans", marker = "python_full_version < '3.13'", specifier = ">=0.11.0" },
+    { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.115.2" },
+    { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.115.2" },
     { name = "google-api-core", specifier = ">=1.26.0" },
     { name = "googleapis-common-protos", specifier = ">=1.70.0" },
     { name = "grpcio", marker = "extra == 'all'", specifier = ">=1.60" },
@@ -135,11 +143,13 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio", "postgresql-asyncpg"], marker = "extra == 'postgresql'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio", "postgresql-asyncpg"], marker = "extra == 'sql'", specifier = ">=2.0.0" },
     { name = "sse-starlette", marker = "extra == 'all'" },
+    { name = "sse-starlette", marker = "extra == 'fastapi'" },
     { name = "sse-starlette", marker = "extra == 'http-server'" },
     { name = "starlette", marker = "extra == 'all'" },
+    { name = "starlette", marker = "extra == 'fastapi'" },
     { name = "starlette", marker = "extra == 'http-server'" },
 ]
-provides-extras = ["all", "db-cli", "encryption", "grpc", "http-server", "mysql", "postgresql", "signing", "sql", "sqlite", "telemetry"]
+provides-extras = ["all", "db-cli", "encryption", "fastapi", "grpc", "http-server", "mysql", "postgresql", "signing", "sql", "sqlite", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Add a `fastapi` optional dependency extra composing `http-server` + `fastapi>=0.115.2`
- Include `a2a-sdk[fastapi]` in the `all` extra
- Update the `ImportError` raised by `add_a2a_routes_to_fastapi` to point users to `a2a-sdk[fastapi]`
- Add a row for the new extra to the README install table

## Why

Follow-up to @ishymko's [review comment on #1024](https://github.com/a2aproject/a2a-python/pull/1024#issuecomment-4565469467):

> there is one gotcha which we missed originally: `http-server` extra no longer contains fastapi as a dependency (see #934) so the error message `install a2a-sdk[http-server]` is not accurate.
>
> To be honest I do not want to bring it back there to keep it lightweight, so wdyt about adding a new `fastapi` extra, i.e. `fastapi = ["a2a-sdk[http-server]", "fastapi>=0.115.2"]`?

Since #934 the `http-server` extra no longer pulls in `fastapi` (kept intentionally lightweight to Starlette + sse-starlette only). As a result, the `ImportError` from `add_a2a_routes_to_fastapi` telling users to install `a2a-sdk[http-server]` was a dead end — that command doesn't install FastAPI and the import would keep failing.

Rather than re-adding `fastapi` to `http-server`, this introduces a dedicated `fastapi` extra that composes `http-server` + FastAPI. The install hint now points to something that actually resolves the missing dependency and `http-server` stays minimal.

The other 5 route modules (`agent_card_routes`, `jsonrpc_routes`, `jsonrpc_dispatcher`, `rest_routes`, `rest_dispatcher`) keep their `a2a-sdk[http-server]` hint — they only depend on Starlette / sse-starlette so that message remains accurate.

## Validation

- `uv run pytest tests/server/routes/test_fastapi_routes.py` — 7 tests, all passing
- `uv lock` — lockfile updated for the new extra