### PR TITLE
fix: replace deprecated FieldDescriptor.label with is_repeated in proto_utils

### DIFF
--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -174,10 +174,7 @@ def parse_params(params: QueryParams, message: ProtobufMessage) -> None:
         field = fields[k]
         v_list = params.getlist(k)
 
-        # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-        # deprecated `field.label` with `field.is_repeated` once the minimum
-        # protobuf version requirement is bumped.
-        if field.label == FieldDescriptor.LABEL_REPEATED:
+        if field.is_repeated:
             accumulated: list[Any] = []
             for v in v_list:
                 if not v:
@@ -211,10 +208,7 @@ def _check_required_field_violation(
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-    # deprecated `field.label` with `field.is_repeated` once the minimum
-    # protobuf version requirement is bumped.
-    if field.label == FieldDescriptor.LABEL_REPEATED:
+    if field.is_repeated:
         if not val:
             return ValidationDetail(
                 field=field.name,
@@ -255,10 +249,7 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-    # deprecated `field.label` with `field.is_repeated` once the minimum
-    # protobuf version requirement is bumped.
-    if field.label != FieldDescriptor.LABEL_REPEATED:
+    if not field.is_repeated:
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)
             _append_nested_errors(errors, field.name, sub_errs)

--- a/tests/utils/test_proto_utils.py
+++ b/tests/utils/test_proto_utils.py
@@ -264,6 +264,25 @@ class TestValidateProtoRequiredFields:
 
         assert {e['field'] for e in errors} == {'message_id', 'role', 'parts'}
 
+    def test_repeated_nested_message_validation(self):
+        """Test _recurse_validation for repeated message fields (Task.history)."""
+        task = Task(
+            id='task-1',
+            context_id='ctx-1',
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+            history=[Message()],  # empty message — missing required fields
+        )
+        with pytest.raises(InvalidParamsError) as exc_info:
+            proto_utils.validate_proto_required_fields(task)
+
+        err = exc_info.value
+        errors = err.data.get('errors', []) if err.data else []
+
+        fields = [e['field'] for e in errors]
+        assert 'history[0].message_id' in fields
+        assert 'history[0].role' in fields
+        assert 'history[0].parts' in fields
+
     def test_nested_required_fields(self):
         """Test nested required fields inside TaskStatus."""
         # Task Status requires 'state'


### PR DESCRIPTION
## Summary

Replace all uses of the deprecated `FieldDescriptor.label == LABEL_REPEATED` pattern with the modern `FieldDescriptor.is_repeated` property in `src/a2a/utils/proto_utils.py`.

The minimum required protobuf version (`>=5.29.5`) already supports `is_repeated` as a stable API, so this change is safe.

## Changes

- `field.label == FieldDescriptor.LABEL_REPEATED` → `field.is_repeated` (2 occurrences)
- `field.label != FieldDescriptor.LABEL_REPEATED` → `not field.is_repeated` (1 occurrence)
- Removed all 3 `TODO` comments referencing #1011

Closes #1011