### PR TITLE
feat: add URL validation infrastructure for SSRF protection

### DIFF
--- a/src/a2a/utils/__init__.py
+++ b/src/a2a/utils/__init__.py
@@ -7,12 +7,26 @@ from a2a.utils.constants import (
     TransportProtocol,
 )
 from a2a.utils.proto_utils import to_stream_response
+from a2a.utils.url_validator import (
+    BlockPrivateNetworks,
+    InvalidUrlError,
+    RequireScheme,
+    ResolvedUrl,
+    UrlValidationRule,
+    UrlValidator,
+)
 
 
 __all__ = [
     'AGENT_CARD_WELL_KNOWN_PATH',
     'DEFAULT_RPC_URL',
+    'BlockPrivateNetworks',
+    'InvalidUrlError',
+    'RequireScheme',
+    'ResolvedUrl',
     'TransportProtocol',
+    'UrlValidationRule',
+    'UrlValidator',
     'proto_utils',
     'to_stream_response',
 ]

--- a/src/a2a/utils/url_validator.py
+++ b/src/a2a/utils/url_validator.py
@@ -38,17 +38,22 @@ Key design decisions:
 
 import asyncio
 import contextlib
+import inspect
 import ipaddress
 import socket
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from typing import cast
 from urllib.parse import SplitResult, urlsplit
 
 
 IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
-Resolver = Callable[[str, int | None], Sequence[IPAddress | str]]
+Resolver = Callable[
+    [str, int | None],
+    Sequence[IPAddress | str] | Awaitable[Sequence[IPAddress | str]],
+]
 
 
 class InvalidUrlError(ValueError):
@@ -215,7 +220,13 @@ class UrlValidator:
 
         try:
             if self._resolver is not None:
-                resolved = self._resolver(host, port)
+                result = self._resolver(host, port)
+                # Support async resolvers (e.g. aiodns) that return
+                # coroutines / awaitables.
+                if inspect.isawaitable(result):
+                    resolved = cast('Sequence[IPAddress | str]', await result)
+                else:
+                    resolved = result
             else:
                 loop = asyncio.get_running_loop()
                 address_info = await loop.getaddrinfo(
@@ -231,20 +242,30 @@ class UrlValidator:
 
         # Normalise resolver output: accept both str and IPAddress
         # instances (fixes review comment on PR #1114).
-        addresses = tuple(
-            dict.fromkeys(
-                addr
-                if isinstance(
-                    addr, (ipaddress.IPv4Address, ipaddress.IPv6Address)
+        try:
+            addresses = tuple(
+                dict.fromkeys(
+                    addr
+                    if isinstance(
+                        addr, (ipaddress.IPv4Address, ipaddress.IPv6Address)
+                    )
+                    else ipaddress.ip_address(addr)
+                    for addr in resolved
                 )
-                else ipaddress.ip_address(addr)
-                for addr in resolved
             )
-        )
+        except ValueError as exc:
+            raise InvalidUrlError(
+                f'Resolver returned invalid address for {host!r}: {exc}'
+            ) from exc
         if not addresses:
             raise InvalidUrlError(f'URL host {host!r} did not resolve.')
         return addresses
 
 
 def _normalize_host(host: str) -> str:
-    return host.rstrip('.').lower()
+    """Normalize a hostname for comparison.
+
+    Strips trailing dots, lowercases, and removes surrounding square
+    brackets from IPv6 literals (e.g. ``[::1]`` → ``::1``).
+    """
+    return host.strip('[]').rstrip('.').lower()

--- a/src/a2a/utils/url_validator.py
+++ b/src/a2a/utils/url_validator.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Composable URL validation utilities for SSRF protection.
+
+This module provides the foundational URL validation infrastructure
+described in issue #1023. It is designed to be composable so that
+domain-specific wrappers (e.g. ``AgentCardUrlValidator``,
+``PushNotificationUrlValidator``) can be built on top of it.
+
+Key design decisions:
+
+* **Composable rules** — validation logic is split into independent
+  ``UrlValidationRule`` implementations that are run in order.  A rule
+  raises ``InvalidUrlError`` to reject; returning means "continue".
+* **Pinned addresses** — ``UrlValidator.validate`` resolves DNS and
+  returns the resolved addresses so callers can pin the connection to
+  a specific IP, preventing DNS-rebinding attacks.
+* **Configurable strictness** — ``BlockPrivateNetworks`` accepts
+  ``allow_hosts`` and ``allow_cidrs`` so deployments that legitimately
+  use private networks can opt in.
+* **Defense in depth** — ``BlockPrivateNetworks`` also inspects the
+  host portion of the URL as a literal IP address when ``resolve=False``
+  is used, so that ``http://127.0.0.1/`` is still rejected even
+  without DNS resolution.
+"""
+
+import asyncio
+import contextlib
+import ipaddress
+import socket
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from urllib.parse import SplitResult, urlsplit
+
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+Resolver = Callable[[str, int | None], Sequence[IPAddress | str]]
+
+
+class InvalidUrlError(ValueError):
+    """Raised when URL validation rejects a URL."""
+
+
+@dataclass(frozen=True)
+class ResolvedUrl:
+    """A parsed URL and the resolved addresses used for validation.
+
+    Callers can use ``addresses`` to pin the outbound connection to a
+    specific IP, preventing DNS-rebinding attacks.
+    """
+
+    raw: str
+    parsed: SplitResult
+    addresses: tuple[IPAddress, ...]
+
+
+class UrlValidationRule(ABC):
+    """A composable URL validation rule.
+
+    Subclass and implement ``check``.  Raise ``InvalidUrlError`` to
+    reject the URL; return normally to allow subsequent rules to run.
+    """
+
+    @abstractmethod
+    async def check(self, url: ResolvedUrl) -> None:
+        """Raise ``InvalidUrlError`` to reject the URL."""
+
+
+class RequireScheme(UrlValidationRule):
+    """Require a URL scheme to be one of the configured schemes.
+
+    Typical usage::
+
+        RequireScheme(['https'])  # HTTPS only
+        RequireScheme(['http', 'https'])  # HTTP or HTTPS
+    """
+
+    def __init__(self, allowed_schemes: Sequence[str]) -> None:
+        if not allowed_schemes:
+            raise ValueError('allowed_schemes must not be empty.')
+        self._allowed_schemes = frozenset(
+            scheme.lower() for scheme in allowed_schemes
+        )
+
+    async def check(self, url: ResolvedUrl) -> None:
+        """Reject URLs whose scheme is not configured as allowed."""
+        scheme = url.parsed.scheme.lower()
+        if scheme not in self._allowed_schemes:
+            allowed = ', '.join(sorted(self._allowed_schemes))
+            raise InvalidUrlError(
+                f'URL scheme {url.parsed.scheme!r} is not allowed. '
+                f'Allowed schemes: {allowed}.'
+            )
+
+
+class BlockPrivateNetworks(UrlValidationRule):
+    """Reject URLs resolving to non-public IP addresses.
+
+    Hosts in ``allow_hosts`` and addresses covered by ``allow_cidrs``
+    are exempt from the non-public address check.
+
+    When ``resolve=False`` is configured on the ``UrlValidator``, the
+    ``addresses`` tuple will be empty.  In that case this rule still
+    inspects the host portion of the URL as a literal IP address so
+    that ``http://127.0.0.1/`` is rejected even without DNS resolution.
+    """
+
+    def __init__(
+        self,
+        *,
+        allow_hosts: Sequence[str] = (),
+        allow_cidrs: Sequence[str] = (),
+    ) -> None:
+        self._allow_hosts = frozenset(
+            _normalize_host(host) for host in allow_hosts
+        )
+        self._allow_networks = tuple(
+            ipaddress.ip_network(cidr, strict=False) for cidr in allow_cidrs
+        )
+
+    async def check(self, url: ResolvedUrl) -> None:
+        """Reject URLs that resolve to non-public addresses."""
+        host = url.parsed.hostname
+        if host is not None and _normalize_host(host) in self._allow_hosts:
+            return
+
+        # Use resolved addresses when available; fall back to parsing
+        # the host as a literal IP for the resolve=False case.
+        addresses = url.addresses
+        if not addresses and host is not None:
+            with contextlib.suppress(ValueError):
+                addresses = (ipaddress.ip_address(host),)
+
+        for address in addresses:
+            if any(address in network for network in self._allow_networks):
+                continue
+            if not address.is_global:
+                raise InvalidUrlError(
+                    f'URL host {host!r} resolves to non-public address '
+                    f'{address}.'
+                )
+
+
+class UrlValidator:
+    """Validate URLs by parsing, resolving, then running rules in order.
+
+    Example::
+
+        validator = UrlValidator(
+            [
+                RequireScheme(['https']),
+                BlockPrivateNetworks(),
+            ]
+        )
+        resolved = await validator.validate('https://example.com/agent')
+        # Use resolved.addresses to pin the connection IP.
+    """
+
+    def __init__(
+        self,
+        rules: Sequence[UrlValidationRule] = (),
+        *,
+        resolve: bool = True,
+        resolver: Resolver | None = None,
+    ) -> None:
+        self._rules = tuple(rules)
+        self._resolve = resolve
+        self._resolver = resolver
+
+    async def validate(self, url: str) -> ResolvedUrl:
+        """Validate a URL and return the parsed URL plus resolved addresses."""
+        resolved = await self._build(url)
+        for rule in self._rules:
+            await rule.check(resolved)
+        return resolved
+
+    async def _build(self, url: str) -> ResolvedUrl:
+        try:
+            parsed = urlsplit(url)
+            host = parsed.hostname
+            port = parsed.port
+        except ValueError as exc:
+            raise InvalidUrlError(f'Invalid URL {url!r}: {exc}') from exc
+
+        addresses: tuple[IPAddress, ...] = ()
+        if self._resolve:
+            if host is None:
+                raise InvalidUrlError(f'URL {url!r} does not include a host.')
+            addresses = await self._resolve_host(host, port)
+
+        return ResolvedUrl(raw=url, parsed=parsed, addresses=addresses)
+
+    async def _resolve_host(
+        self, host: str, port: int | None
+    ) -> tuple[IPAddress, ...]:
+        # Fast path: host is already a literal IP address.
+        try:
+            return (ipaddress.ip_address(host),)
+        except ValueError:
+            pass
+
+        try:
+            if self._resolver is not None:
+                resolved = self._resolver(host, port)
+            else:
+                loop = asyncio.get_running_loop()
+                address_info = await loop.getaddrinfo(
+                    host,
+                    port,
+                    type=socket.SOCK_STREAM,
+                )
+                resolved = [info[4][0] for info in address_info]
+        except OSError as exc:
+            raise InvalidUrlError(
+                f'Could not resolve URL host {host!r}: {exc}'
+            ) from exc
+
+        # Normalise resolver output: accept both str and IPAddress
+        # instances (fixes review comment on PR #1114).
+        addresses = tuple(
+            dict.fromkeys(
+                addr
+                if isinstance(
+                    addr, (ipaddress.IPv4Address, ipaddress.IPv6Address)
+                )
+                else ipaddress.ip_address(addr)
+                for addr in resolved
+            )
+        )
+        if not addresses:
+            raise InvalidUrlError(f'URL host {host!r} did not resolve.')
+        return addresses
+
+
+def _normalize_host(host: str) -> str:
+    return host.rstrip('.').lower()

--- a/tests/utils/test_url_validator.py
+++ b/tests/utils/test_url_validator.py
@@ -1,0 +1,446 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for a2a.utils.url_validator."""
+
+import ipaddress
+
+import pytest
+
+from a2a.utils.url_validator import (
+    BlockPrivateNetworks,
+    InvalidUrlError,
+    RequireScheme,
+    ResolvedUrl,
+    UrlValidationRule,
+    UrlValidator,
+)
+
+
+class RecordingRule(UrlValidationRule):
+    """Records the resolved URL passed to the rule."""
+
+    def __init__(self) -> None:
+        self.seen: list[ResolvedUrl] = []
+
+    async def check(self, url: ResolvedUrl) -> None:
+        self.seen.append(url)
+
+
+# ---------------------------------------------------------------------------
+# UrlValidator — basic validation & resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_resolves_and_returns_pinned_addresses() -> None:
+    """UrlValidator returns parsed URL details and resolved addresses."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        assert host == 'example.com'
+        assert port == 443
+        return ['93.184.216.34', '93.184.216.34']
+
+    rule = RecordingRule()
+    validator = UrlValidator(
+        [RequireScheme(['https']), rule],
+        resolver=resolver,
+    )
+
+    result = await validator.validate('https://example.com:443/agent')
+
+    assert result.raw == 'https://example.com:443/agent'
+    assert result.parsed.scheme == 'https'
+    assert result.parsed.hostname == 'example.com'
+    assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+    assert rule.seen == [result]
+
+
+@pytest.mark.asyncio
+async def test_validate_deduplicates_resolved_addresses() -> None:
+    """Duplicate addresses from the resolver are deduplicated."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['93.184.216.34', '93.184.216.34', '93.184.216.34']
+
+    validator = UrlValidator(resolver=resolver)
+
+    result = await validator.validate('http://example.com/')
+
+    assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_ip_address_host() -> None:
+    """Literal IP addresses in the host are resolved without DNS."""
+
+    validator = UrlValidator([RequireScheme(['http'])])
+
+    result = await validator.validate('http://93.184.216.34/agent')
+
+    assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_ipv6_host() -> None:
+    """IPv6 literal addresses are resolved correctly."""
+
+    validator = UrlValidator([RequireScheme(['http'])])
+
+    result = await validator.validate('http://[::1]/agent')
+
+    assert result.addresses == (ipaddress.ip_address('::1'),)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_url_without_host_when_resolving() -> None:
+    """URL resolution requires a host."""
+
+    validator = UrlValidator([RequireScheme(['https'])])
+
+    with pytest.raises(InvalidUrlError, match='does not include a host'):
+        await validator.validate('https:///missing-host')
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_invalid_url() -> None:
+    """Malformed URLs are reported as InvalidUrlError."""
+
+    validator = UrlValidator(resolve=False)
+
+    with pytest.raises(InvalidUrlError, match='Invalid URL'):
+        await validator.validate('http://example.com:not-a-port')
+
+
+@pytest.mark.asyncio
+async def test_validate_reports_resolution_failures() -> None:
+    """Resolver failures are reported as InvalidUrlError."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        raise OSError('name lookup failed')
+
+    validator = UrlValidator(resolver=resolver)
+
+    with pytest.raises(InvalidUrlError, match='Could not resolve URL host'):
+        await validator.validate('http://example.com/callback')
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_empty_resolution_result() -> None:
+    """Resolvers must return at least one address."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return []
+
+    validator = UrlValidator(resolver=resolver)
+
+    with pytest.raises(InvalidUrlError, match='did not resolve'):
+        await validator.validate('http://example.com/callback')
+
+
+@pytest.mark.asyncio
+async def test_validate_without_resolution_runs_rules_with_empty_addresses() -> (
+    None
+):
+    """UrlValidator can skip DNS resolution for parse-only validation."""
+    rule = RecordingRule()
+    validator = UrlValidator([rule], resolve=False)
+
+    result = await validator.validate('custom://agent/path')
+
+    assert result.parsed.scheme == 'custom'
+    assert result.addresses == ()
+    assert rule.seen == [result]
+
+
+@pytest.mark.asyncio
+async def test_validate_no_rules_passes() -> None:
+    """A validator with no rules always succeeds."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['93.184.216.34']
+
+    validator = UrlValidator(resolver=resolver)
+
+    result = await validator.validate('http://example.com/')
+
+    assert result.parsed.hostname == 'example.com'
+
+
+# ---------------------------------------------------------------------------
+# RequireScheme
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_require_scheme_rejects_disallowed_scheme() -> None:
+    """RequireScheme rejects URLs whose scheme is not allowed."""
+    validator = UrlValidator(
+        [RequireScheme(['https'])],
+        resolve=False,
+    )
+
+    with pytest.raises(InvalidUrlError, match='not allowed'):
+        await validator.validate('http://example.com')
+
+
+@pytest.mark.asyncio
+async def test_require_scheme_allows_configured_scheme() -> None:
+    """RequireScheme allows URLs whose scheme is in the allowed set."""
+    validator = UrlValidator(
+        [RequireScheme(['http', 'https'])],
+        resolve=False,
+    )
+
+    result = await validator.validate('http://example.com')
+
+    assert result.parsed.scheme == 'http'
+
+
+def test_require_scheme_rejects_empty_allowed_schemes() -> None:
+    """RequireScheme needs at least one allowed scheme."""
+    with pytest.raises(ValueError, match='must not be empty'):
+        RequireScheme([])
+
+
+@pytest.mark.asyncio
+async def test_require_scheme_is_case_insensitive() -> None:
+    """Scheme comparison is case-insensitive."""
+    validator = UrlValidator(
+        [RequireScheme(['HTTPS'])],
+        resolve=False,
+    )
+
+    result = await validator.validate('https://example.com')
+
+    assert result.parsed.scheme == 'https'
+
+
+# ---------------------------------------------------------------------------
+# BlockPrivateNetworks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_rejects_loopback_address() -> None:
+    """BlockPrivateNetworks rejects non-public resolved addresses."""
+    validator = UrlValidator([BlockPrivateNetworks()])
+
+    with pytest.raises(InvalidUrlError, match='non-public address 127.0.0.1'):
+        await validator.validate('http://127.0.0.1/callback')
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_rejects_private_10_network() -> None:
+    """BlockPrivateNetworks rejects 10.x.x.x addresses."""
+    validator = UrlValidator([BlockPrivateNetworks()])
+
+    with pytest.raises(InvalidUrlError, match='non-public address'):
+        await validator.validate('http://10.0.0.1/callback')
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_rejects_private_192_network() -> None:
+    """BlockPrivateNetworks rejects 192.168.x.x addresses."""
+    validator = UrlValidator([BlockPrivateNetworks()])
+
+    with pytest.raises(InvalidUrlError, match='non-public address'):
+        await validator.validate('http://192.168.1.1/callback')
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_rejects_ipv6_loopback() -> None:
+    """BlockPrivateNetworks rejects IPv6 loopback."""
+    validator = UrlValidator([BlockPrivateNetworks()])
+
+    with pytest.raises(InvalidUrlError, match='non-public address'):
+        await validator.validate('http://[::1]/callback')
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_allows_public_address() -> None:
+    """BlockPrivateNetworks allows public IP addresses."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['93.184.216.34']
+
+    validator = UrlValidator([BlockPrivateNetworks()], resolver=resolver)
+
+    result = await validator.validate('http://example.com/callback')
+
+    assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_allows_configured_host() -> None:
+    """BlockPrivateNetworks allows explicitly configured hosts."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['127.0.0.1']
+
+    validator = UrlValidator(
+        [BlockPrivateNetworks(allow_hosts=['internal.example.test'])],
+        resolver=resolver,
+    )
+
+    result = await validator.validate('http://internal.example.test/callback')
+
+    assert result.addresses == (ipaddress.ip_address('127.0.0.1'),)
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_allows_configured_cidr() -> None:
+    """BlockPrivateNetworks allows addresses in configured CIDRs."""
+    validator = UrlValidator([BlockPrivateNetworks(allow_cidrs=['10.0.0.0/8'])])
+
+    result = await validator.validate('http://10.1.2.3/callback')
+
+    assert result.addresses == (ipaddress.ip_address('10.1.2.3'),)
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_rejects_mixed_disallowed_address() -> (
+    None
+):
+    """All resolved addresses must be public or explicitly allowed."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['93.184.216.34', '10.1.2.3']
+
+    validator = UrlValidator([BlockPrivateNetworks()], resolver=resolver)
+
+    with pytest.raises(InvalidUrlError, match='10.1.2.3'):
+        await validator.validate('http://example.com/callback')
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_rejects_literal_ip_without_resolve() -> (
+    None
+):
+    """BlockPrivateNetworks still rejects literal private IPs when resolve=False.
+
+    This is the defense-in-depth fix for the review comment on PR #1114:
+    even without DNS resolution, ``http://127.0.0.1/`` must be rejected.
+    """
+    validator = UrlValidator(
+        [BlockPrivateNetworks()],
+        resolve=False,
+    )
+
+    with pytest.raises(InvalidUrlError, match='non-public address 127.0.0.1'):
+        await validator.validate('http://127.0.0.1/callback')
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_allows_hostname_without_resolve() -> None:
+    """When resolve=False and host is not a literal IP, the rule passes."""
+
+    validator = UrlValidator(
+        [BlockPrivateNetworks()],
+        resolve=False,
+    )
+
+    # Hostname cannot be parsed as IP → addresses empty → rule passes
+    result = await validator.validate('http://internal.example.test/callback')
+
+    assert result.parsed.hostname == 'internal.example.test'
+
+
+@pytest.mark.asyncio
+async def test_block_private_networks_allow_host_is_case_insensitive() -> None:
+    """allow_hosts matching is case-insensitive and strips trailing dots."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['127.0.0.1']
+
+    validator = UrlValidator(
+        [BlockPrivateNetworks(allow_hosts=['Internal.Example.TEST.'])],
+        resolver=resolver,
+    )
+
+    result = await validator.validate('http://internal.example.test/callback')
+
+    assert result.addresses == (ipaddress.ip_address('127.0.0.1'),)
+
+
+# ---------------------------------------------------------------------------
+# Resolver returning IPAddress objects (PR #1114 review fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_returning_ipaddress_objects() -> None:
+    """Custom resolvers may return IPAddress objects directly."""
+
+    def resolver(host: str, port: int | None) -> list[ipaddress.IPv4Address]:
+        return [ipaddress.ip_address('93.184.216.34')]
+
+    validator = UrlValidator(resolver=resolver)
+
+    result = await validator.validate('http://example.com/')
+
+    assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+
+
+# ---------------------------------------------------------------------------
+# Rule composition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rules_run_in_order() -> None:
+    """Rules are executed in the order they are provided."""
+    order: list[str] = []
+
+    class FirstRule(UrlValidationRule):
+        async def check(self, url: ResolvedUrl) -> None:
+            order.append('first')
+
+    class SecondRule(UrlValidationRule):
+        async def check(self, url: ResolvedUrl) -> None:
+            order.append('second')
+
+    validator = UrlValidator(
+        [FirstRule(), SecondRule()],
+        resolve=False,
+    )
+
+    await validator.validate('http://example.com/')
+
+    assert order == ['first', 'second']
+
+
+@pytest.mark.asyncio
+async def test_first_rejecting_rule_stops_further_checks() -> None:
+    """When a rule rejects, subsequent rules are not executed."""
+    order: list[str] = []
+
+    class RejectingRule(UrlValidationRule):
+        async def check(self, url: ResolvedUrl) -> None:
+            order.append('rejecting')
+            raise InvalidUrlError('rejected')
+
+    class NeverReachedRule(UrlValidationRule):
+        async def check(self, url: ResolvedUrl) -> None:
+            order.append('never')
+
+    validator = UrlValidator(
+        [RejectingRule(), NeverReachedRule()],
+        resolve=False,
+    )
+
+    with pytest.raises(InvalidUrlError, match='rejected'):
+        await validator.validate('http://example.com/')
+
+    assert order == ['rejecting']

--- a/tests/utils/test_url_validator.py
+++ b/tests/utils/test_url_validator.py
@@ -374,6 +374,23 @@ async def test_block_private_networks_allow_host_is_case_insensitive() -> None:
     assert result.addresses == (ipaddress.ip_address('127.0.0.1'),)
 
 
+@pytest.mark.asyncio
+async def test_block_private_networks_allow_ipv6_with_brackets() -> None:
+    """allow_hosts strips surrounding brackets from IPv6 literals."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['::1']
+
+    validator = UrlValidator(
+        [BlockPrivateNetworks(allow_hosts=['[::1]'])],
+        resolver=resolver,
+    )
+
+    result = await validator.validate('http://[::1]/callback')
+
+    assert result.addresses == (ipaddress.ip_address('::1'),)
+
+
 # ---------------------------------------------------------------------------
 # Resolver returning IPAddress objects (PR #1114 review fix)
 # ---------------------------------------------------------------------------
@@ -391,6 +408,35 @@ async def test_resolver_returning_ipaddress_objects() -> None:
     result = await validator.validate('http://example.com/')
 
     assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_is_awaited() -> None:
+    """Custom resolvers may return awaitables (e.g. aiodns)."""
+
+    async def resolver(host: str, port: int | None) -> list[str]:
+        return ['93.184.216.34']
+
+    validator = UrlValidator(resolver=resolver)
+
+    result = await validator.validate('http://example.com/')
+
+    assert result.addresses == (ipaddress.ip_address('93.184.216.34'),)
+
+
+@pytest.mark.asyncio
+async def test_resolver_returning_invalid_address_raises_invalid_url_error() -> (
+    None
+):
+    """Resolver returning non-IP strings raises InvalidUrlError."""
+
+    def resolver(host: str, port: int | None) -> list[str]:
+        return ['not-an-ip-address']
+
+    validator = UrlValidator(resolver=resolver)
+
+    with pytest.raises(InvalidUrlError, match='invalid address'):
+        await validator.validate('http://example.com/')
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements composable URL validation rules to protect against SSRF attacks when fetching Agent Cards and processing webhook URLs. Closes #1023.

## Changes

### New files
- **`src/a2a/utils/url_validator.py`** — Core implementation (251 lines)
- **`tests/utils/test_url_validator.py`** — 31 test cases, 96% module coverage

### Modified files
- **`src/a2a/utils/__init__.py`** — Export new public symbols

## Implementation Details

### Public API
| Symbol | Description |
|--------|-------------|
| `InvalidUrlError` | Exception raised when a URL is rejected by validation |
| `ResolvedUrl` | Frozen dataclass: original URL + parsed result + resolved IP addresses |
| `UrlValidationRule` | Abstract base class for composable validation rules |
| `RequireScheme` | Rule restricting allowed URL schemes (e.g. HTTPS only) |
| `BlockPrivateNetworks` | Rule rejecting private/loopback addresses with `allow_hosts` and `allow_cidrs` exemptions |
| `UrlValidator` | Core validator: resolve → pin → validate through configurable rule chain |

### Design (per issue #1023)
- **Composable rules** — validation logic is split into independent `UrlValidationRule` implementations run in order; a rule raises `InvalidUrlError` to reject, returning means "continue"
- **Pinned addresses** — `UrlValidator.validate` resolves DNS and returns resolved addresses so callers can pin the connection to a specific IP, preventing DNS-rebinding attacks
- **Configurable strictness** — `BlockPrivateNetworks` accepts `allow_hosts` and `allow_cidrs` so deployments that legitimately use private networks can opt in
- **Defense in depth** — `BlockPrivateNetworks` also inspects the host portion of the URL as a literal IP address when `resolve=False` is used, so `http://127.0.0.1/` is still rejected even without DNS resolution

### Review Feedback Addressed (commit `175f198`)
1. **Async resolver support**: `_resolve_host` now checks `inspect.isawaitable(result)` and awaits if the custom resolver returns a coroutine — supports both sync and async resolvers (e.g. aiodns)
2. **Consistent error type**: `ValueError` from `ipaddress.ip_address()` on invalid resolver output is now caught and re-raised as `InvalidUrlError`, ensuring all validation failures use the same exception type
3. **IPv6 bracket normalization**: `_normalize_host()` strips surrounding square brackets from IPv6 literals (e.g. `[::1]` → `::1`), ensuring consistent matching in `allow_hosts`

## Test Plan
- [x] 31/31 unit tests pass
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes
- [x] Overall coverage 93% (≥88% threshold)
- [x] Module coverage 96%
- [x] Full test suite: 1377 passed

## Security Impact
- **Before**: No URL validation — SSRF via agent card URLs or webhook URLs possible
- **After**: Composable rules enforce scheme restrictions and block private network access with configurable exemptions