### PR TITLE
fix(utils): protobuf-compatible repeated field detection

### DIFF
--- a/src/a2a/utils/proto_utils.py
+++ b/src/a2a/utils/proto_utils.py
@@ -174,10 +174,7 @@ def parse_params(params: QueryParams, message: ProtobufMessage) -> None:
         field = fields[k]
         v_list = params.getlist(k)
 
-        # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-        # deprecated `field.label` with `field.is_repeated` once the minimum
-        # protobuf version requirement is bumped.
-        if field.label == FieldDescriptor.LABEL_REPEATED:
+        if _is_field_repeated(field):
             accumulated: list[Any] = []
             for v in v_list:
                 if not v:
@@ -206,15 +203,20 @@ class ValidationDetail(TypedDict):
     message: str
 
 
+def _is_field_repeated(field: FieldDescriptor) -> bool:
+    """Return whether a protobuf field is repeated across protobuf versions."""
+    try:
+        return field.is_repeated
+    except AttributeError:
+        return field.label == FieldDescriptor.LABEL_REPEATED
+
+
 def _check_required_field_violation(
     msg: ProtobufMessage, field: FieldDescriptor
 ) -> ValidationDetail | None:
     """Check if a required field is missing or invalid."""
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-    # deprecated `field.label` with `field.is_repeated` once the minimum
-    # protobuf version requirement is bumped.
-    if field.label == FieldDescriptor.LABEL_REPEATED:
+    if _is_field_repeated(field):
         if not val:
             return ValidationDetail(
                 field=field.name,
@@ -255,10 +257,7 @@ def _recurse_validation(
         return errors
 
     val = getattr(msg, field.name)
-    # TODO(https://github.com/a2aproject/a2a-python/issues/1011): Replace
-    # deprecated `field.label` with `field.is_repeated` once the minimum
-    # protobuf version requirement is bumped.
-    if field.label != FieldDescriptor.LABEL_REPEATED:
+    if not _is_field_repeated(field):
         if msg.HasField(field.name):
             sub_errs = _validate_proto_required_fields_internal(val)
             _append_nested_errors(errors, field.name, sub_errs)

--- a/tests/utils/test_proto_utils.py
+++ b/tests/utils/test_proto_utils.py
@@ -241,6 +241,31 @@ class TestRestParams:
         ).url.params
 
 
+class TestIsFieldRepeated:
+    """Tests for _is_field_repeated helper."""
+
+    def test_scalar_field_not_repeated(self):
+        field = Message.DESCRIPTOR.fields_by_name['message_id']
+        assert proto_utils._is_field_repeated(field) is False
+
+    def test_repeated_field(self):
+        field = AgentSkill.DESCRIPTOR.fields_by_name['tags']
+        assert proto_utils._is_field_repeated(field) is True
+
+    def test_fallback_when_is_repeated_missing(self, monkeypatch):
+        field = AgentSkill.DESCRIPTOR.fields_by_name['tags']
+
+        def raise_attribute_error(_self):
+            raise AttributeError('is_repeated')
+
+        monkeypatch.setattr(
+            type(field),
+            'is_repeated',
+            property(raise_attribute_error),
+        )
+        assert proto_utils._is_field_repeated(field) is True
+
+
 class TestValidateProtoRequiredFields:
     """Tests for validate_proto_required_fields function."""
 


### PR DESCRIPTION
## Summary

- Add `_is_field_repeated()` in `proto_utils` that prefers `field.is_repeated` and falls back to `field.label == FieldDescriptor.LABEL_REPEATED` when the newer API is unavailable.
- Replace the three repeated-field checks in REST param parsing and proto required-field validation with the helper.
- Add unit tests for scalar/repeated fields and for the label fallback path.

## Problem

`proto_utils` used the deprecated `FieldDescriptor.label` API. Protobuf 7 removes `label`, which breaks validation on newer runtimes even though the SDK dependency range can resolve protobuf 7.x in some environments.

## Test plan

- [x] `uv run pytest tests/utils/test_proto_utils.py -q`
- [x] Verified `_is_field_repeated` against protobuf 6.x locally (is_repeated + label both present)

Fixes #1011
