### PR TITLE
test(server): add xfail repros for cancel leaving no terminal state

### DIFF
--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -2253,3 +2253,120 @@ async def test_scenario_context_id_visibility(use_legacy, streaming):
     # Verify that agent can see context_id the same as in task_1 and different task id
     assert agent_context2_id == agent_context1_id
     assert agent_task2_id != agent_task1_id
+
+
+# Scenario 19: cancel must close the task out when the executor does not.
+#
+# The empty-cancel scenario above only passes because its executor
+# hand-enqueues a CANCELED event, next to a "TODO: this should be done
+# automatically by the framework ?" comment. These two use an executor whose
+# cancel() really is empty, which is the shape InputRequiredAgent, SlowAgent
+# and DummyAgentExecutor all use in this file.
+_TERMINAL_STATES = {
+    TaskState.TASK_STATE_CANCELED,
+    TaskState.TASK_STATE_COMPLETED,
+    TaskState.TASK_STATE_FAILED,
+    TaskState.TASK_STATE_REJECTED,
+}
+
+
+async def _start_task(client, text):
+    it = client.send_message(
+        SendMessageRequest(
+            message=Message(
+                message_id='test-msg',
+                role=Role.ROLE_USER,
+                parts=[Part(text=text)],
+            ),
+            configuration=SendMessageConfiguration(return_immediately=True),
+        )
+    )
+    res = await it.__anext__()
+    return res.task.id if res.HasField('task') else res.status_update.task_id
+
+
+@pytest.mark.timeout(5.0)
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason='https://github.com/a2aproject/a2a-python/issues/1170 - '
+    'ActiveTask.cancel cancels the producer before awaiting the executor '
+    'cancel, so nothing writes a terminal state',
+)
+async def test_scenario_19_mid_run_cancel_reaches_a_terminal_state():
+    """A caller who cancels should at least be able to stop polling."""
+    started = asyncio.Event()
+    hang = asyncio.Event()
+
+    class SilentCancelAgent(AgentExecutor):
+        async def execute(
+            self, context: RequestContext, event_queue: EventQueue
+        ):
+            task = new_task_from_user_message(context.message)
+            task.status.state = TaskState.TASK_STATE_WORKING
+            await event_queue.enqueue_event(task)
+            started.set()
+            await hang.wait()
+
+        async def cancel(
+            self, context: RequestContext, event_queue: EventQueue
+        ):
+            pass
+
+    client = await create_client(
+        create_handler(SilentCancelAgent(), use_legacy=False),
+        agent_card=agent_card(),
+        streaming=True,
+    )
+    task_id = await _start_task(client, 'hello')
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await client.cancel_task(CancelTaskRequest(id=task_id))
+    task_after = await client.get_task(GetTaskRequest(id=task_id))
+
+    assert task_after.status.state in _TERMINAL_STATES
+
+
+@pytest.mark.timeout(5.0)
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason='https://github.com/a2aproject/a2a-python/issues/1170 - '
+    'V2 on_cancel_task dropped the V1 post-check, so cancelling a parked '
+    'task reports success with the task unchanged',
+)
+async def test_scenario_19_cancel_of_parked_task_does_not_silently_succeed():
+    """input-required is non-terminal, so cancel should either work or raise
+    TaskNotCancelableError. Reporting success and changing nothing is the one
+    outcome a caller cannot act on."""
+
+    class ParkingAgent(AgentExecutor):
+        async def execute(
+            self, context: RequestContext, event_queue: EventQueue
+        ):
+            task = new_task_from_user_message(context.message)
+            task.status.state = TaskState.TASK_STATE_INPUT_REQUIRED
+            await event_queue.enqueue_event(task)
+
+        async def cancel(
+            self, context: RequestContext, event_queue: EventQueue
+        ):
+            pass
+
+    client = await create_client(
+        create_handler(ParkingAgent(), use_legacy=False),
+        agent_card=agent_card(),
+        streaming=True,
+    )
+    task_id = await _start_task(client, 'start')
+
+    for _ in range(50):
+        parked = await client.get_task(GetTaskRequest(id=task_id))
+        if parked.status.state == TaskState.TASK_STATE_INPUT_REQUIRED:
+            break
+        await asyncio.sleep(0.02)
+    assert parked.status.state == TaskState.TASK_STATE_INPUT_REQUIRED
+
+    result = await client.cancel_task(CancelTaskRequest(id=task_id))
+
+    assert result.status.state != TaskState.TASK_STATE_INPUT_REQUIRED


### PR DESCRIPTION
Adds two failing scenarios for #1170, both `xfail(strict=True)` so they sit green in CI today and flip loudly the moment someone fixes the underlying bug.

No fix here, just the repro. #1170 has the analysis and two possible fix shapes, and which one you want depends on calls that are yours to make (particularly whether the framework should close a task out when the executor didn't, which an existing TODO in this file already raises).

## What they cover

Both drive `DefaultRequestHandlerV2` through the real client with an executor whose `cancel()` is empty:

- `test_scenario_19_mid_run_cancel_reaches_a_terminal_state` cancels mid-run. The task stays `working` forever, so a caller has no way to know it can stop polling. The assertion is deliberately weak: any terminal state passes, not specifically `canceled`.
- `test_scenario_19_cancel_of_parked_task_does_not_silently_succeed` cancels a task parked in `input-required`. Cancel returns success with the task unchanged. This one asserts only that the state must not come back unchanged, so it stays agnostic on whether a parked task should be cancelable. Cancelling it or raising `TaskNotCancelableError` would both pass.

## Why an empty `cancel()`

`test_scenario_cancel_working_task_empty_cancel` already covers the mid-run case and passes, because its executor hand-enqueues the `CANCELED` event, right below a `# TODO: this should be done automatically by the framework ?` comment. These two are that same scenario with the hand-written event removed.

`InputRequiredAgent`, `SlowAgent` and `DummyAgentExecutor` in this file all define `cancel()` as `pass` already, so the shape isn't unusual. It's also what a real executor looks like when its cancel path only does teardown.

## Notes

Only `DefaultRequestHandlerV2`, no `use_legacy` parametrize. The legacy handler hangs on both of these rather than failing, since `on_cancel_task` waits in `consume_all` for an event the empty executor never sends. That seemed like a separate thing and not worth entangling with this.

Pure addition, 117 lines, no existing test touched and no new dependencies. `ruff check` and `ruff format --check` are clean. `tests/integration` goes from 427 passed / 1 xpassed to 427 passed / 2 xfailed / 1 xpassed, and the two new ones run in about 0.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
