### PR TITLE
fix: remove zombie registry entries when ActiveTask start fails

### DIFF
--- a/src/a2a/server/agent_execution/active_task_registry.py
+++ b/src/a2a/server/agent_execution/active_task_registry.py
@@ -90,10 +90,26 @@ class ActiveTaskRegistry:
                 raise TaskNotFoundError
             return existing
 
-        await active_task.start(
-            call_context=call_context,
-            create_task_if_missing=create_task_if_missing,
-        )
+        try:
+            await active_task.start(
+                call_context=call_context,
+                create_task_if_missing=create_task_if_missing,
+            )
+        except Exception:
+            # Remove the entry synchronously instead of relying on the
+            # fire-and-forget _on_active_task_cleanup path scheduled by
+            # ActiveTask.start() on failure. That cleanup runs in a separate
+            # task and may not execute before another request checks the
+            # registry, leaving a zombie entry for a task that never started.
+            # The pop itself is non-blocking, so holding the (sync) RLock
+            # briefly inside the async path is safe.
+            with self._lock:
+                self._active_tasks.pop(task_id, None)
+                logger.debug(
+                    'Removed failed active task for %s from registry',
+                    task_id,
+                )
+            raise
         return active_task
 
     def _on_active_task_cleanup(self, active_task: ActiveTask) -> None:

--- a/tests/server/agent_execution/test_active_task_registry.py
+++ b/tests/server/agent_execution/test_active_task_registry.py
@@ -177,7 +177,7 @@ async def test_get_or_create_cache_hit_is_owner_scoped():
 async def test_get_or_create_failed_start_removes_zombie_entry():
     """A failed start() must not leave a zombie registry entry.
 
-    Regression test for BUG-45: the entry was inserted before start(), and
+    Regression test for zombie-entry cleanup: the entry was inserted before start(), and
     the cleanup on failure was fire-and-forget, so a subsequent registry
     lookup could still see the never-started task.
     """

--- a/tests/server/agent_execution/test_active_task_registry.py
+++ b/tests/server/agent_execution/test_active_task_registry.py
@@ -170,3 +170,42 @@ async def test_get_or_create_cache_hit_is_owner_scoped():
     assert again is active
 
     await registry.aclose()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_get_or_create_failed_start_removes_zombie_entry():
+    """A failed start() must not leave a zombie registry entry.
+
+    Regression test for BUG-45: the entry was inserted before start(), and
+    the cleanup on failure was fire-and-forget, so a subsequent registry
+    lookup could still see the never-started task.
+    """
+    from a2a.types.a2a_pb2 import Task, TaskState, TaskStatus
+    from a2a.utils.errors import InvalidParamsError
+
+    task_store = InMemoryTaskStore()
+    terminal_task = Task(
+        id='task-term',
+        context_id='c1',
+        status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+    )
+    await task_store.save(terminal_task, ServerCallContext())
+
+    registry = ActiveTaskRegistry(
+        agent_executor=_SlowExecutor(),
+        task_store=task_store,
+    )
+
+    with pytest.raises(InvalidParamsError):
+        await registry.get_or_create(
+            'task-term',
+            call_context=ServerCallContext(),
+            create_task_if_missing=True,
+        )
+
+    # Give any fire-and-forget cleanup tasks a chance to run; the entry must
+    # already be gone regardless.
+    await asyncio.sleep(0)
+    assert await registry.get('task-term') is None
+    assert 'task-term' not in registry._active_tasks


### PR DESCRIPTION
## What changed

### 1. Remove registry entries synchronously when `ActiveTask.start()` fails

**Problem:** `ActiveTaskRegistry.get_or_create()` (`src/a2a/server/agent_execution/active_task_registry.py`) inserts the `ActiveTask` into `_active_tasks` *before* calling `start()`. If `start()` raises (e.g. the task is already in a terminal state), the only cleanup was the fire-and-forget `asyncio.create_task(self._remove_task(...))` scheduled via `_on_active_task_cleanup` inside `ActiveTask.start()`. That cleanup runs asynchronously and may not execute before another request checks the registry, leaving a zombie entry for a task that never started — and a concurrent `get_or_create` could return the half-started task.

**Fix (src/a2a/server/agent_execution/active_task_registry.py):**
- Wrapped the `start()` call in `get_or_create()` with `try/except`; on any failure the entry is removed synchronously under `_lock` before the exception propagates.
- The removal is idempotent (`pop`), so the fire-and-forget cleanup task scheduled by `ActiveTask.start()` remains harmless if it runs later.

## Testing

- `./.venv/Scripts/python -m pytest tests/server/agent_execution/test_active_task_registry.py -q` → **6 passed** (includes new `test_get_or_create_failed_start_removes_zombie_entry`, which seeds a completed task so `start()` raises `InvalidParamsError`, then asserts the registry no longer contains the task).
- `./.venv/Scripts/python -m pytest tests/server/agent_execution/ -q` → **73 passed**.
- `./.venv/Scripts/python -m pytest tests/server/request_handlers/test_default_request_handler_v2.py -q` → **59 passed** (registry consumers unaffected).
- `./.venv/Scripts/python -m ruff check` on modified files: clean.
- Behavior change: none for the success path; on a failed `start()` the registry is now guaranteed not to retain the task.
