### PR TITLE
fix: validate task state transitions (block terminal escape)

### DIFF
--- a/src/a2a/server/agent_execution/active_task.py
+++ b/src/a2a/server/agent_execution/active_task.py
@@ -75,17 +75,12 @@ from a2a.utils.errors import (
     InvalidParamsError,
     TaskNotFoundError,
 )
+from a2a.utils.task import TERMINAL_TASK_STATES
 
 
 logger = logging.getLogger(__name__)
 
 
-TERMINAL_TASK_STATES = {
-    TaskState.TASK_STATE_COMPLETED,
-    TaskState.TASK_STATE_CANCELED,
-    TaskState.TASK_STATE_FAILED,
-    TaskState.TASK_STATE_REJECTED,
-}
 INTERRUPTED_TASK_STATES = {
     TaskState.TASK_STATE_AUTH_REQUIRED,
     TaskState.TASK_STATE_INPUT_REQUIRED,

--- a/src/a2a/server/tasks/task_manager.py
+++ b/src/a2a/server/tasks/task_manager.py
@@ -40,10 +40,7 @@ def validate_state_transition(
         InvalidAgentResponseError: If the transition moves a task away from
             a terminal state.
     """
-    if (
-        current_state in TERMINAL_TASK_STATES
-        and new_state != current_state
-    ):
+    if current_state in TERMINAL_TASK_STATES and new_state != current_state:
         raise InvalidAgentResponseError(
             message=(
                 f'Illegal state transition from terminal state '

--- a/src/a2a/server/tasks/task_manager.py
+++ b/src/a2a/server/tasks/task_manager.py
@@ -19,6 +19,40 @@ from a2a.utils.telemetry import trace_function
 logger = logging.getLogger(__name__)
 
 
+TERMINAL_TASK_STATES = {
+    TaskState.TASK_STATE_COMPLETED,
+    TaskState.TASK_STATE_CANCELED,
+    TaskState.TASK_STATE_FAILED,
+    TaskState.TASK_STATE_REJECTED,
+}
+
+
+def validate_state_transition(
+    current_state: TaskState, new_state: TaskState
+) -> None:
+    """Validates a task state transition before it is persisted.
+
+    Terminal states are final: a task in COMPLETED/CANCELED/FAILED/REJECTED
+    must never move to a different state (including back to SUBMITTED).
+    Re-persisting the same terminal state is tolerated for idempotency.
+
+    Raises:
+        InvalidAgentResponseError: If the transition moves a task away from
+            a terminal state.
+    """
+    if (
+        current_state in TERMINAL_TASK_STATES
+        and new_state != current_state
+    ):
+        raise InvalidAgentResponseError(
+            message=(
+                f'Illegal state transition from terminal state '
+                f'{TaskState.Name(current_state)} to '
+                f'{TaskState.Name(new_state)}'
+            )
+        )
+
+
 @trace_function()
 def append_artifact_to_task(task: Task, event: TaskArtifactUpdateEvent) -> None:
     """Helper method for updating a Task object with new artifact data from an event.
@@ -204,6 +238,7 @@ class TaskManager:
             logger.debug(
                 'Updating task %s status to: %s', task.id, event.status.state
             )
+            validate_state_transition(task.status.state, event.status.state)
             if task.status.HasField('message'):
                 task.history.append(task.status.message)
             if event.metadata:

--- a/src/a2a/server/tasks/task_manager.py
+++ b/src/a2a/server/tasks/task_manager.py
@@ -13,18 +13,11 @@ from a2a.types.a2a_pb2 import (
     TaskStatusUpdateEvent,
 )
 from a2a.utils.errors import InvalidAgentResponseError, InvalidParamsError
+from a2a.utils.task import TERMINAL_TASK_STATES
 from a2a.utils.telemetry import trace_function
 
 
 logger = logging.getLogger(__name__)
-
-
-TERMINAL_TASK_STATES = {
-    TaskState.TASK_STATE_COMPLETED,
-    TaskState.TASK_STATE_CANCELED,
-    TaskState.TASK_STATE_FAILED,
-    TaskState.TASK_STATE_REJECTED,
-}
 
 
 def validate_state_transition(

--- a/src/a2a/utils/task.py
+++ b/src/a2a/utils/task.py
@@ -5,9 +5,20 @@ import binascii
 from base64 import b64decode, b64encode
 from typing import Literal, Protocol, runtime_checkable
 
-from a2a.types.a2a_pb2 import Task
+from a2a.types.a2a_pb2 import Task, TaskState
 from a2a.utils.constants import MAX_LIST_TASKS_PAGE_SIZE
 from a2a.utils.errors import InvalidParamsError
+
+# States from which a task cannot transition to any other state.
+# Single source of truth shared by the server modules (task_manager,
+# active_task, request handlers) so terminal-state semantics cannot drift
+# between them.
+TERMINAL_TASK_STATES = {
+    TaskState.TASK_STATE_COMPLETED,
+    TaskState.TASK_STATE_CANCELED,
+    TaskState.TASK_STATE_FAILED,
+    TaskState.TASK_STATE_REJECTED,
+}
 
 
 @runtime_checkable

--- a/tests/server/tasks/test_task_manager.py
+++ b/tests/server/tasks/test_task_manager.py
@@ -486,7 +486,7 @@ def test_validate_state_transition_allows_legal_transitions(current, new):
 async def test_save_task_event_blocks_terminal_overwrite():
     """save_task_event must reject a terminal -> non-terminal status update.
 
-    Regression test for BUG-43: the status was blindly overwritten, so a
+    Regression test for terminal-state protection: the status was blindly overwritten, so a
     misbehaving agent could move a completed task back to SUBMITTED.
     """
     from a2a.server.tasks import InMemoryTaskStore

--- a/tests/server/tasks/test_task_manager.py
+++ b/tests/server/tasks/test_task_manager.py
@@ -444,3 +444,76 @@ def test_append_artifact_to_task():
         match='append=True for nonexistent artifact_id',
     ):
         append_artifact_to_task(task, append_event_5)
+
+
+@pytest.mark.parametrize(
+    ('current', 'new'),
+    [
+        (TaskState.TASK_STATE_COMPLETED, TaskState.TASK_STATE_SUBMITTED),
+        (TaskState.TASK_STATE_COMPLETED, TaskState.TASK_STATE_WORKING),
+        (TaskState.TASK_STATE_CANCELED, TaskState.TASK_STATE_SUBMITTED),
+        (TaskState.TASK_STATE_FAILED, TaskState.TASK_STATE_WORKING),
+        (TaskState.TASK_STATE_REJECTED, TaskState.TASK_STATE_COMPLETED),
+    ],
+)
+def test_validate_state_transition_blocks_terminal_escape(current, new):
+    """A terminal state must never transition to a different state."""
+    from a2a.server.tasks.task_manager import validate_state_transition
+
+    with pytest.raises(InvalidAgentResponseError):
+        validate_state_transition(current, new)
+
+
+@pytest.mark.parametrize(
+    ('current', 'new'),
+    [
+        (TaskState.TASK_STATE_COMPLETED, TaskState.TASK_STATE_COMPLETED),
+        (TaskState.TASK_STATE_SUBMITTED, TaskState.TASK_STATE_WORKING),
+        (TaskState.TASK_STATE_SUBMITTED, TaskState.TASK_STATE_COMPLETED),
+        (TaskState.TASK_STATE_WORKING, TaskState.TASK_STATE_COMPLETED),
+        (TaskState.TASK_STATE_WORKING, TaskState.TASK_STATE_INPUT_REQUIRED),
+        (TaskState.TASK_STATE_INPUT_REQUIRED, TaskState.TASK_STATE_WORKING),
+    ],
+)
+def test_validate_state_transition_allows_legal_transitions(current, new):
+    """Legal forward transitions (and idempotent repeats) are accepted."""
+    from a2a.server.tasks.task_manager import validate_state_transition
+
+    validate_state_transition(current, new)
+
+
+@pytest.mark.asyncio
+async def test_save_task_event_blocks_terminal_overwrite():
+    """save_task_event must reject a terminal -> non-terminal status update.
+
+    Regression test for BUG-43: the status was blindly overwritten, so a
+    misbehaving agent could move a completed task back to SUBMITTED.
+    """
+    from a2a.server.tasks import InMemoryTaskStore
+    from a2a.server.tasks.task_manager import TaskManager
+
+    task_store = InMemoryTaskStore()
+    task_manager = TaskManager(
+        task_id=MINIMAL_TASK_ID,
+        context_id=MINIMAL_CONTEXT_ID,
+        task_store=task_store,
+        initial_message=None,
+        context=TEST_CONTEXT,
+    )
+
+    task = create_minimal_task()
+    task.status.state = TaskState.TASK_STATE_COMPLETED
+    await task_store.save(task, TEST_CONTEXT)
+
+    illegal_event = TaskStatusUpdateEvent(
+        task_id=MINIMAL_TASK_ID,
+        context_id=MINIMAL_CONTEXT_ID,
+        status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED),
+    )
+
+    with pytest.raises(InvalidAgentResponseError):
+        await task_manager.save_task_event(illegal_event)
+
+    # The task state must be unchanged.
+    stored = await task_store.get(MINIMAL_TASK_ID, TEST_CONTEXT)
+    assert stored.status.state == TaskState.TASK_STATE_COMPLETED


### PR DESCRIPTION
## What changed

### 1. Validate task state transitions before persisting status updates

**Problem:** `TaskManager.save_task_event()` (`src/a2a/server/tasks/task_manager.py`) blindly overwrote the task status with `task.status.CopyFrom(event.status)` for every `TaskStatusUpdateEvent`. A misbehaving or malicious agent could move a task that is already in a terminal state (COMPLETED/CANCELED/FAILED/REJECTED) back to SUBMITTED (or to another state), rewriting the persisted terminal outcome. `active_task.py:571` was already guarded (`if task.status.state not in TERMINAL_TASK_STATES`) and needed no change.

**Fix (src/a2a/server/tasks/task_manager.py):**
- Added `TERMINAL_TASK_STATES` and `validate_state_transition(current_state, new_state)`, which raises `InvalidAgentResponseError` when a terminal state would transition to any *different* state (including back to SUBMITTED). Re-persisting the same terminal state is tolerated for idempotency, and all forward transitions (SUBMITTED→WORKING→terminal, interrupted states, etc.) are unaffected.
- `save_task_event()` now calls `validate_state_transition()` before `task.status.CopyFrom(...)`. Both the V1 path (ResultAggregator → `TaskManager`) and the V2 path (`ActiveTask` EventConsumer → `TaskManager`) flow through this single chokepoint.

## Testing

- `./.venv/Scripts/python -m pytest tests/server/tasks/test_task_manager.py -q` → **29 passed** (includes new tests: parametrized rejection of every terminal→other transition, acceptance of legal forward/idempotent transitions, and an end-to-end `save_task_event` regression test asserting a completed task cannot be moved back to SUBMITTED and the store is unchanged).
- `./.venv/Scripts/python -m pytest tests/server/request_handlers/ tests/server/agent_execution/ tests/server/tasks/ tests/server/events/ -q` → **551 passed, 90 skipped, 3 xfailed** (pre-existing xfails reference upstream issue #869).
- `./.venv/Scripts/python -m ruff check` on modified files: clean.
- Behavior change: status updates that would move a terminal task to a different state now fail with `InvalidAgentResponseError` (-32006) instead of silently overwriting the persisted state. All legitimate agent flows (including REJECTED/CANCELED) are unaffected.
