### PR TITLE
fix: sanitize internal error messages in JSON-RPC and gRPC paths

### DIFF
--- a/src/a2a/server/request_handlers/grpc_handler.py
+++ b/src/a2a/server/request_handlers/grpc_handler.py
@@ -136,6 +136,9 @@ class GrpcHandler(a2a_grpc.A2AServiceServicer):
             result = await handler_func(server_context)
         except A2AError as e:
             await self.abort_context(e, context)
+        except Exception:
+            logger.exception('Unhandled exception in gRPC handler')
+            await self.abort_context(types.InternalError(), context)
         else:
             return result
         return default_response
@@ -153,6 +156,9 @@ class GrpcHandler(a2a_grpc.A2AServiceServicer):
                 yield item
         except A2AError as e:
             await self.abort_context(e, context)
+        except Exception:
+            logger.exception('Unhandled exception in gRPC handler')
+            await self.abort_context(types.InternalError(), context)
 
     async def SendMessage(
         self,
@@ -413,9 +419,13 @@ class GrpcHandler(a2a_grpc.A2AServiceServicer):
             context.set_trailing_metadata(tuple(new_metadata))
             await context.abort(rich_status.code, rich_status.details)
         else:
+            logger.error(
+                'Unknown error type during request handling',
+                exc_info=error,
+            )
             await context.abort(
                 grpc.StatusCode.UNKNOWN,
-                f'Unknown error type: {error}',
+                'Unknown error',
             )
 
     def _build_call_context(

--- a/src/a2a/server/routes/jsonrpc_dispatcher.py
+++ b/src/a2a/server/routes/jsonrpc_dispatcher.py
@@ -177,7 +177,9 @@ class JsonRpcDispatcher:
             A `JSONResponse` object formatted as a JSON-RPC error response.
         """
         if not isinstance(error, A2AError | JSONRPCError):
-            error = InternalError(message=str(error))
+            # Never leak internal exception details to the client; the
+            # original error was logged by the caller.
+            error = InternalError()
 
         response_data = build_error_response(request_id, error)
         error_info = response_data.get('error', {})
@@ -251,11 +253,11 @@ class JsonRpcDispatcher:
                             message="Invalid request: 'jsonrpc' must be exactly '2.0'"
                         ),
                     )
-            except Exception as e:
+            except Exception:
                 logger.exception('Failed to validate base JSON-RPC request')
                 return self._generate_error_response(
                     request_id,
-                    InvalidRequestError(data=str(e)),
+                    InvalidRequestError(),
                 )
 
             # 2) Route by method name; unknown -> -32601, known -> validate params (-32602 on failure)
@@ -289,11 +291,11 @@ class JsonRpcDispatcher:
                 # Parse the params field into the proto message type
                 params = body.get('params', {})
                 specific_request = ParseDict(params, model_class())
-            except Exception as e:
+            except Exception:
                 logger.exception('Failed to parse request params')
                 return self._generate_error_response(
                     request_id,
-                    InvalidParamsError(data=str(e)),
+                    InvalidParamsError(),
                 )
 
             # 3) Build call context and wrap the request for downstream handling
@@ -335,10 +337,10 @@ class JsonRpcDispatcher:
             raise e
         except A2AError as e:
             return self._generate_error_response(request_id, e)
-        except Exception as e:
+        except Exception:
             logger.exception('Unhandled exception')
             return self._generate_error_response(
-                request_id, InternalError(message=str(e))
+                request_id, InternalError()
             )
 
     @validate_version(constants.PROTOCOL_VERSION_1_0)
@@ -585,7 +587,7 @@ class JsonRpcDispatcher:
                     rpc_error: A2AError | JSONRPCError = (
                         e
                         if isinstance(e, A2AError | JSONRPCError)
-                        else InternalError(message=str(e))
+                        else InternalError()
                     )
                     error_response = build_error_response(
                         context.state.get('request_id'), rpc_error

--- a/src/a2a/server/routes/jsonrpc_dispatcher.py
+++ b/src/a2a/server/routes/jsonrpc_dispatcher.py
@@ -339,9 +339,7 @@ class JsonRpcDispatcher:
             return self._generate_error_response(request_id, e)
         except Exception:
             logger.exception('Unhandled exception')
-            return self._generate_error_response(
-                request_id, InternalError()
-            )
+            return self._generate_error_response(request_id, InternalError())
 
     @validate_version(constants.PROTOCOL_VERSION_1_0)
     async def _process_streaming_request(

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -12,6 +12,7 @@ from a2a.auth.user import User
 from a2a.client.client import ClientConfig
 from a2a.client.client_factory import ClientFactory
 from a2a.client.errors import A2AClientError
+from a2a.utils.errors import A2AError
 from a2a.helpers.proto_helpers import new_task_from_user_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.context import ServerCallContext
@@ -469,7 +470,9 @@ async def test_scenario_9_error_before_blocking(use_legacy, streaming):
     )
 
     # TODO: Is it correct error code ?
-    with pytest.raises(A2AClientError, match='TEST_ERROR_IN_EXECUTE'):
+    # Agent exceptions are sanitized server-side (internal details are
+    # logged, not exposed to clients); clients receive the generic error.
+    with pytest.raises(A2AError, match='Internal error'):
         async for _ in client.send_message(
             SendMessageRequest(
                 message=msg,
@@ -548,7 +551,9 @@ async def test_scenario_12_13_error_after_initial_event(use_legacy, streaming):
 
         tasks.append(asyncio.create_task(release_agent()))
 
-    with pytest.raises(A2AClientError, match='TEST_ERROR_IN_EXECUTE'):
+    # Agent exceptions are sanitized server-side (internal details are
+    # logged, not exposed to clients); clients receive the generic error.
+    with pytest.raises(A2AError, match='Internal error'):
         async for _ in it:
             pass
 
@@ -678,7 +683,9 @@ async def test_scenario_15_subscribe_error(use_legacy):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(consume_task, timeout=0.1)
     else:
-        with pytest.raises(A2AClientError, match='TEST_ERROR_IN_EXECUTE'):
+        # Agent exceptions are sanitized server-side (internal details are
+        # logged, not exposed to clients); clients receive the generic error.
+        with pytest.raises(A2AError, match='Internal error'):
             await consume_task
 
     (task,) = (await client.list_tasks(ListTasksRequest())).tasks

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -11,7 +11,6 @@ import pytest_asyncio
 from a2a.auth.user import User
 from a2a.client.client import ClientConfig
 from a2a.client.client_factory import ClientFactory
-from a2a.client.errors import A2AClientError
 from a2a.helpers.proto_helpers import new_task_from_user_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.context import ServerCallContext

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -12,7 +12,6 @@ from a2a.auth.user import User
 from a2a.client.client import ClientConfig
 from a2a.client.client_factory import ClientFactory
 from a2a.client.errors import A2AClientError
-from a2a.utils.errors import A2AError
 from a2a.helpers.proto_helpers import new_task_from_user_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.context import ServerCallContext
@@ -50,6 +49,7 @@ from a2a.types.a2a_pb2 import (
 )
 from a2a.utils import TransportProtocol
 from a2a.utils.errors import (
+    A2AError,
     InvalidAgentResponseError,
     InvalidParamsError,
     TaskNotCancelableError,

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -1028,8 +1028,9 @@ async def test_scenario_19_no_parallel_executions(use_legacy, streaming):
 
     # Verify that both calls for clients finished.
     if use_legacy and not streaming:
-        # Legacy handler fails on first execution.
-        with pytest.raises(A2AClientError, match='NoTaskQueue'):
+        # Legacy handler fails on first execution; the failure is
+        # sanitized server-side (internal details are logged, not exposed).
+        with pytest.raises(A2AError, match='Internal error'):
             await task1
     else:
         await task1

--- a/tests/integration/test_scenarios.py
+++ b/tests/integration/test_scenarios.py
@@ -615,7 +615,9 @@ async def test_scenario_14_error_in_cancel(use_legacy, streaming):
 
     await asyncio.wait_for(started_event.wait(), timeout=1.0)
 
-    with pytest.raises(A2AClientError, match='TEST_ERROR_IN_CANCEL'):
+    # Agent exceptions are sanitized server-side; clients receive the
+    # generic error.
+    with pytest.raises(A2AError, match='Internal error'):
         await client.cancel_task(CancelTaskRequest(id=task_id))
 
     (task,) = (await client.list_tasks(ListTasksRequest())).tasks

--- a/tests/server/request_handlers/test_grpc_handler.py
+++ b/tests/server/request_handlers/test_grpc_handler.py
@@ -754,7 +754,7 @@ async def test_unhandled_exception_is_sanitized(
     mock_request_handler: AsyncMock,
     mock_grpc_context: AsyncMock,
 ) -> None:
-    """A non-A2A exception must not leak its message to the client (BUG-46)."""
+    """A non-A2A exception must not leak its message to the client."""
     mock_request_handler.on_get_task.side_effect = RuntimeError(
         'internal detail: /secret/path'
     )
@@ -775,7 +775,7 @@ async def test_unknown_a2a_error_type_is_sanitized(
     mock_request_handler: AsyncMock,
     mock_grpc_context: AsyncMock,
 ) -> None:
-    """An A2AError outside the mapping must not leak details (BUG-46)."""
+    """An A2AError outside the mapping must not leak details."""
     from a2a.utils.errors import A2AError
 
     class CustomError(A2AError):

--- a/tests/server/request_handlers/test_grpc_handler.py
+++ b/tests/server/request_handlers/test_grpc_handler.py
@@ -746,3 +746,49 @@ class TestTenantExtraction:
         server_context = call_args[0][1]
         assert isinstance(server_context, ServerCallContext)
         assert server_context.tenant == ''
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_is_sanitized(
+    grpc_handler: GrpcHandler,
+    mock_request_handler: AsyncMock,
+    mock_grpc_context: AsyncMock,
+) -> None:
+    """A non-A2A exception must not leak its message to the client (BUG-46)."""
+    mock_request_handler.on_get_task.side_effect = RuntimeError(
+        'internal detail: /secret/path'
+    )
+    request_proto = a2a_pb2.GetTaskRequest(id='any')
+
+    await grpc_handler.GetTask(request_proto, mock_grpc_context)
+
+    mock_grpc_context.abort.assert_awaited_once()
+    call_args, _ = mock_grpc_context.abort.call_args
+    assert call_args[0] == grpc.StatusCode.INTERNAL
+    assert 'internal detail' not in call_args[1]
+    assert 'INTERNAL' in call_args[1] or 'Internal error' in call_args[1]
+
+
+@pytest.mark.asyncio
+async def test_unknown_a2a_error_type_is_sanitized(
+    grpc_handler: GrpcHandler,
+    mock_request_handler: AsyncMock,
+    mock_grpc_context: AsyncMock,
+) -> None:
+    """An A2AError outside the mapping must not leak details (BUG-46)."""
+    from a2a.utils.errors import A2AError
+
+    class CustomError(A2AError):
+        message = 'custom'
+
+    mock_request_handler.on_get_task.side_effect = CustomError(
+        'sensitive internals here'
+    )
+    request_proto = a2a_pb2.GetTaskRequest(id='any')
+
+    await grpc_handler.GetTask(request_proto, mock_grpc_context)
+
+    mock_grpc_context.abort.assert_awaited_once()
+    call_args, _ = mock_grpc_context.abort.call_args
+    assert call_args[0] == grpc.StatusCode.UNKNOWN
+    assert 'sensitive internals' not in call_args[1]

--- a/tests/server/routes/test_jsonrpc_dispatcher.py
+++ b/tests/server/routes/test_jsonrpc_dispatcher.py
@@ -655,7 +655,7 @@ if __name__ == '__main__':
     pytest.main([__file__])
 
 
-# --- Error sanitization (BUG-12 / BUG-46) ---
+# --- Error sanitization ---
 
 
 class TestErrorSanitization:

--- a/tests/server/routes/test_jsonrpc_dispatcher.py
+++ b/tests/server/routes/test_jsonrpc_dispatcher.py
@@ -653,3 +653,57 @@ class TestJsonRpcDispatcherMethodRouting:
 
 if __name__ == '__main__':
     pytest.main([__file__])
+
+
+# --- Error sanitization (BUG-12 / BUG-46) ---
+
+
+class TestErrorSanitization:
+    def test_unhandled_exception_does_not_leak(self, client, mock_handler):
+        """Non-A2A exceptions must not leak their message to the client."""
+        mock_handler.on_get_task.side_effect = RuntimeError(
+            'internal detail: /secret/path'
+        )
+        response = client.post(
+            '/',
+            json={
+                'jsonrpc': '2.0',
+                'id': '1',
+                'method': 'GetTask',
+                'params': {'id': 'task1'},
+            },
+        )
+        data = response.json()
+        assert data['error']['code'] == -32603  # InternalError
+        assert data['error']['message'] == 'Internal error'
+        assert 'internal detail' not in response.text
+
+    def test_malformed_params_does_not_leak(self, client):
+        """Parse failures must not leak the raw parse error to the client."""
+        response = client.post(
+            '/',
+            json={
+                'jsonrpc': '2.0',
+                'id': '1',
+                'method': 'GetTask',
+                # id must be a string; a dict fails proto parsing.
+                'params': {'id': {'nested': 'invalid'}},
+            },
+        )
+        data = response.json()
+        assert data['error']['code'] == -32602  # InvalidParamsError
+        assert 'nested' not in response.text
+
+    def test_invalid_base_request_does_not_leak(self, client):
+        """Base JSON-RPC validation failures must not leak details."""
+        response = client.post(
+            '/',
+            json={
+                'jsonrpc': '2.0',
+                'id': '1',
+                'method': 'GetTask',
+                'params': 'not-a-dict',
+            },
+        )
+        data = response.json()
+        assert data['error']['code'] == -32600  # InvalidRequestError

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -898,7 +898,7 @@ def test_validation_error(client: TestClient):
 
 
 def test_unhandled_exception(client: TestClient, handler: mock.AsyncMock):
-    """Test handling unhandled exception."""
+    """Test handling unhandled exception without leaking internal details."""
     handler.on_get_task.side_effect = Exception('Unexpected error')
 
     response = client.post(
@@ -914,7 +914,9 @@ def test_unhandled_exception(client: TestClient, handler: mock.AsyncMock):
     data = response.json()
     assert 'error' in data
     assert data['error']['code'] == InternalError().code
-    assert 'Unexpected error' in data['error']['message']
+    # The internal exception message must not leak to the client.
+    assert data['error']['message'] == 'Internal error'
+    assert 'Unexpected error' not in data['error']['message']
 
 
 def test_get_method_to_rpc_endpoint(client: TestClient):


### PR DESCRIPTION
## What changed

### 1. Stop leaking internal exception details in JSON-RPC errors

**Problem:** The JSON-RPC dispatcher (`src/a2a/server/routes/jsonrpc_dispatcher.py`) embedded the raw exception text into client-visible errors in four places: base request validation (`InvalidRequestError(data=str(e))`), param parsing (`InvalidParamsError(data=str(e))`), the unhandled-exception path (`InternalError(message=str(e))`), and the SSE stream error path (`InternalError(message=str(e))`). The generic defensive conversion in `_generate_error_response()` also used `InternalError(message=str(error))`. This leaks internal paths, library versions, and stack details to clients (fingerprinting / information disclosure).

**Fix (src/a2a/server/routes/jsonrpc_dispatcher.py):**
- All four call sites now return the corresponding A2A error with its default (generic) message; the original exception is still logged server-side via `logger.exception(...)`.
- `_generate_error_response()` converts unknown errors to a bare `InternalError()` ("Internal error") instead of embedding `str(error)`.

### 2. Stop leaking unknown exception details in the gRPC handler

**Problem:** `GrpcHandler` (`src/a2a/server/request_handlers/grpc_handler.py`) leaked exception details in two ways: non-A2A exceptions were not caught by `_handle_unary`/`_handle_stream` and propagated to the gRPC framework with their message text; and the `abort_context()` fallback sent `Unknown error type: {error}`, embedding the exception repr.

**Fix (src/a2a/server/request_handlers/grpc_handler.py):**
- `_handle_unary` and `_handle_stream` now catch generic `Exception`, log it, and abort with `InternalError` (INTERNAL / "Internal error").
- `abort_context()`'s fallback now logs the unknown error and aborts with a generic `"Unknown error"` message instead of embedding the error repr.

## Testing

- `./.venv/Scripts/python -m pytest tests/server/routes/test_jsonrpc_dispatcher.py tests/server/request_handlers/test_grpc_handler.py tests/server/test_integration.py -q` → **97 passed** (includes new sanitization tests for the unhandled-exception, malformed-params and invalid-base-request paths, plus gRPC unhandled-exception and unknown-A2A-error paths; all assert the internal text does not appear in the response).
- `./.venv/Scripts/python -m pytest tests/compat/v0_3/ -q` → **250 passed** (v0.3 compat unaffected).
- Updated `tests/server/test_integration.py::test_unhandled_exception` to assert the generic `"Internal error"` message and the absence of the exception text (previously it asserted the leaked message).
- `./.venv/Scripts/python -m ruff check` on modified files: clean.
- Behavior change: non-A2A exception messages are no longer sent to clients over JSON-RPC or gRPC; clients now receive `Internal error` / `Unknown error`. Error codes are unchanged.
