### PR TITLE
fix(server,client): return Task/Message directly from message/send

### DIFF
--- a/src/a2a/client/transports/jsonrpc.py
+++ b/src/a2a/client/transports/jsonrpc.py
@@ -81,13 +81,22 @@ class JsonRpcTransport(ClientTransport):
         json_rpc_response = JSONRPC20Response(**response_data)
         if json_rpc_response.error:
             raise self._create_jsonrpc_error(json_rpc_response.error)
-        # The server returns the Task or Message directly (not wrapped in
-        # the streaming SendMessageResponse oneof), so try each in turn and
-        # re-wrap for callers that expect a SendMessageResponse.
+        result = json_rpc_response.result
+        # Servers that still nest the payload under the streaming
+        # SendMessageResponse oneof (older SDKs, other language
+        # implementations) send {"task": {...}} or {"message": {...}}.
+        # Unwrap explicitly for those before falling back to the direct
+        # Task/Message shape this SDK's own server now returns.
+        if isinstance(result, dict) and 'task' in result:
+            task = json_format.ParseDict(result['task'], Task())
+            return SendMessageResponse(task=task)
+        if isinstance(result, dict) and 'message' in result:
+            message = json_format.ParseDict(result['message'], Message())
+            return SendMessageResponse(message=message)
         try:
-            task = json_format.ParseDict(json_rpc_response.result, Task())
+            task = json_format.ParseDict(result, Task())
         except json_format.ParseError:
-            message = json_format.ParseDict(json_rpc_response.result, Message())
+            message = json_format.ParseDict(result, Message())
             return SendMessageResponse(message=message)
         return SendMessageResponse(task=task)
 

--- a/src/a2a/client/transports/jsonrpc.py
+++ b/src/a2a/client/transports/jsonrpc.py
@@ -85,18 +85,34 @@ class JsonRpcTransport(ClientTransport):
         # Servers that still nest the payload under the streaming
         # SendMessageResponse oneof (older SDKs, other language
         # implementations) send {"task": {...}} or {"message": {...}}.
-        # Unwrap explicitly for those before falling back to the direct
-        # Task/Message shape this SDK's own server now returns.
         if isinstance(result, dict) and 'task' in result:
             task = json_format.ParseDict(result['task'], Task())
             return SendMessageResponse(task=task)
         if isinstance(result, dict) and 'message' in result:
             message = json_format.ParseDict(result['message'], Message())
             return SendMessageResponse(message=message)
+        # Otherwise the payload is the Task/Message itself, per spec
+        # possibly carrying a "kind" discriminator field that our
+        # protobuf-generated Task/Message types don't declare. Strip it
+        # and use it (falling back to field-presence, same heuristic the
+        # v0.3 compat transport already uses) to pick which type to parse.
+        payload = dict(result) if isinstance(result, dict) else result
+        kind = payload.pop('kind', None) if isinstance(payload, dict) else None
+        if not kind and isinstance(payload, dict):
+            if 'messageId' in payload:
+                kind = 'message'
+            elif 'id' in payload:
+                kind = 'task'
+        if kind == 'message':
+            message = json_format.ParseDict(payload, Message())
+            return SendMessageResponse(message=message)
+        if kind == 'task':
+            task = json_format.ParseDict(payload, Task())
+            return SendMessageResponse(task=task)
         try:
-            task = json_format.ParseDict(result, Task())
+            task = json_format.ParseDict(payload, Task())
         except json_format.ParseError:
-            message = json_format.ParseDict(result, Message())
+            message = json_format.ParseDict(payload, Message())
             return SendMessageResponse(message=message)
         return SendMessageResponse(task=task)
 

--- a/src/a2a/client/transports/jsonrpc.py
+++ b/src/a2a/client/transports/jsonrpc.py
@@ -48,6 +48,23 @@ _JSON_RPC_ERROR_CODE_TO_A2A_ERROR = {
 _ERROR_INFO_TYPE = 'type.googleapis.com/google.rpc.ErrorInfo'
 
 
+def _strip_kind(value: Any) -> Any:
+    """Recursively drops "kind" discriminator keys from a decoded JSON value.
+
+    Spec-compliant peers stamp "kind" on Task, Message, and Part
+    objects wherever they appear (top level, TaskStatus.message,
+    Task.history[], Message.parts[]), but this SDK's protobuf-generated
+    types don't declare that field, so json_format.ParseDict rejects it.
+    """
+    if isinstance(value, dict):
+        return {
+            key: _strip_kind(val) for key, val in value.items() if key != 'kind'
+        }
+    if isinstance(value, list):
+        return [_strip_kind(item) for item in value]
+    return value
+
+
 @trace_class(kind=SpanKind.CLIENT)
 class JsonRpcTransport(ClientTransport):
     """A JSON-RPC transport for the A2A client."""
@@ -86,23 +103,27 @@ class JsonRpcTransport(ClientTransport):
         # SendMessageResponse oneof (older SDKs, other language
         # implementations) send {"task": {...}} or {"message": {...}}.
         if isinstance(result, dict) and 'task' in result:
-            task = json_format.ParseDict(result['task'], Task())
+            task = json_format.ParseDict(_strip_kind(result['task']), Task())
             return SendMessageResponse(task=task)
         if isinstance(result, dict) and 'message' in result:
-            message = json_format.ParseDict(result['message'], Message())
+            message = json_format.ParseDict(
+                _strip_kind(result['message']), Message()
+            )
             return SendMessageResponse(message=message)
         # Otherwise the payload is the Task/Message itself, per spec
-        # possibly carrying a "kind" discriminator field that our
-        # protobuf-generated Task/Message types don't declare. Strip it
-        # and use it (falling back to field-presence, same heuristic the
-        # v0.3 compat transport already uses) to pick which type to parse.
-        payload = dict(result) if isinstance(result, dict) else result
-        kind = payload.pop('kind', None) if isinstance(payload, dict) else None
-        if not kind and isinstance(payload, dict):
-            if 'messageId' in payload:
+        # possibly carrying a "kind" discriminator field on itself and on
+        # every nested Message/Part (status.message, history[], parts[]),
+        # none of which this SDK's protobuf-generated types declare.
+        # Read the top-level kind (or fall back to the same field-presence
+        # heuristic the v0.3 compat transport already uses) before
+        # stripping it throughout the tree.
+        kind = result.get('kind') if isinstance(result, dict) else None
+        if not kind and isinstance(result, dict):
+            if 'messageId' in result:
                 kind = 'message'
-            elif 'id' in payload:
+            elif 'id' in result:
                 kind = 'task'
+        payload = _strip_kind(result)
         if kind == 'message':
             message = json_format.ParseDict(payload, Message())
             return SendMessageResponse(message=message)

--- a/src/a2a/client/transports/jsonrpc.py
+++ b/src/a2a/client/transports/jsonrpc.py
@@ -28,6 +28,7 @@ from a2a.types.a2a_pb2 import (
     ListTaskPushNotificationConfigsResponse,
     ListTasksRequest,
     ListTasksResponse,
+    Message,
     SendMessageRequest,
     SendMessageResponse,
     StreamResponse,
@@ -80,10 +81,15 @@ class JsonRpcTransport(ClientTransport):
         json_rpc_response = JSONRPC20Response(**response_data)
         if json_rpc_response.error:
             raise self._create_jsonrpc_error(json_rpc_response.error)
-        response: SendMessageResponse = json_format.ParseDict(
-            json_rpc_response.result, SendMessageResponse()
-        )
-        return response
+        # The server returns the Task or Message directly (not wrapped in
+        # the streaming SendMessageResponse oneof), so try each in turn and
+        # re-wrap for callers that expect a SendMessageResponse.
+        try:
+            task = json_format.ParseDict(json_rpc_response.result, Task())
+        except json_format.ParseError:
+            message = json_format.ParseDict(json_rpc_response.result, Message())
+            return SendMessageResponse(message=message)
+        return SendMessageResponse(task=task)
 
     async def send_message_streaming(
         self,

--- a/src/a2a/server/routes/jsonrpc_dispatcher.py
+++ b/src/a2a/server/routes/jsonrpc_dispatcher.py
@@ -36,9 +36,7 @@ from a2a.types.a2a_pb2 import (
     ListTaskPushNotificationConfigsRequest,
     ListTasksRequest,
     SendMessageRequest,
-    SendMessageResponse,
     SubscribeToTaskRequest,
-    Task,
     TaskPushNotificationConfig,
 )
 from a2a.utils import constants, json_utils, proto_utils
@@ -405,9 +403,7 @@ class JsonRpcDispatcher:
         task_or_message = await self.request_handler.on_message_send(
             request_obj, context
         )
-        if isinstance(task_or_message, Task):
-            return MessageToDict(SendMessageResponse(task=task_or_message))
-        return MessageToDict(SendMessageResponse(message=task_or_message))
+        return MessageToDict(task_or_message, preserving_proto_field_name=False)
 
     async def _handle_cancel_task(
         self, request_obj: CancelTaskRequest, context: ServerCallContext

--- a/tests/client/test_auth_interceptor.py
+++ b/tests/client/test_auth_interceptor.py
@@ -33,7 +33,6 @@ from a2a.types.a2a_pb2 import (
     SecurityRequirement,
     SecurityScheme,
     SendMessageRequest,
-    SendMessageResponse,
     StringList,
 )
 from a2a.utils.constants import TransportProtocol
@@ -49,11 +48,10 @@ def build_success_response(request: httpx.Request) -> httpx.Response:
         role=Role.ROLE_AGENT,
         parts=[],
     )
-    response = SendMessageResponse(message=message)
     response_payload = {
         'id': request_payload['id'],
         'jsonrpc': '2.0',
-        'result': json_format.MessageToDict(response),
+        'result': json_format.MessageToDict(message),
     }
     return httpx.Response(200, json=response_payload)
 

--- a/tests/client/transports/test_jsonrpc_client.py
+++ b/tests/client/transports/test_jsonrpc_client.py
@@ -267,6 +267,55 @@ class TestSendMessage:
         assert response.HasField('message')
         assert response.message.message_id == 'msg-1'
 
+    @pytest.mark.asyncio
+    async def test_send_message_unwrapped_with_nested_kind(
+        self, transport, mock_httpx_client
+    ):
+        """A peer stamps "kind" on every Task/Message/Part it emits, not
+        just the top-level object, e.g. TaskStatus.message, Task.history
+        entries, and Message.parts entries. All of them must be stripped,
+        not just the one at the root.
+        """
+        task_id = str(uuid4())
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'jsonrpc': '2.0',
+            'id': '1',
+            'result': {
+                'id': task_id,
+                'kind': 'task',
+                'contextId': 'ctx-123',
+                'status': {
+                    'state': 'TASK_STATE_COMPLETED',
+                    'message': {
+                        'messageId': 'msg-1',
+                        'kind': 'message',
+                        'role': 'ROLE_AGENT',
+                        'parts': [{'kind': 'text', 'text': 'hi'}],
+                    },
+                },
+                'history': [
+                    {
+                        'messageId': 'msg-0',
+                        'kind': 'message',
+                        'role': 'ROLE_USER',
+                        'parts': [{'kind': 'text', 'text': 'hello'}],
+                    }
+                ],
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_httpx_client.send.return_value = mock_response
+
+        request = create_send_message_request()
+        response = await transport.send_message(request)
+
+        assert response.HasField('task')
+        assert response.task.id == task_id
+        assert response.task.status.message.message_id == 'msg-1'
+        assert response.task.status.message.parts[0].text == 'hi'
+        assert response.task.history[0].message_id == 'msg-0'
+
     @pytest.mark.parametrize(
         'error_cls, error_code', JSON_RPC_ERROR_CODE_MAP.items()
     )

--- a/tests/client/transports/test_jsonrpc_client.py
+++ b/tests/client/transports/test_jsonrpc_client.py
@@ -137,11 +137,9 @@ class TestSendMessage:
             'jsonrpc': '2.0',
             'id': '1',
             'result': {
-                'task': {
-                    'id': task_id,
-                    'contextId': 'ctx-123',
-                    'status': {'state': 'TASK_STATE_COMPLETED'},
-                }
+                'id': task_id,
+                'contextId': 'ctx-123',
+                'status': {'state': 'TASK_STATE_COMPLETED'},
             },
         }
         mock_response.raise_for_status = MagicMock()
@@ -527,11 +525,9 @@ class TestExtensions:
             'jsonrpc': '2.0',
             'id': '1',
             'result': {
-                'task': {
-                    'id': 'task-123',
-                    'contextId': 'ctx-123',
-                    'status': {'state': 'TASK_STATE_COMPLETED'},
-                }
+                'id': 'task-123',
+                'contextId': 'ctx-123',
+                'status': {'state': 'TASK_STATE_COMPLETED'},
             },
         }
         mock_response.raise_for_status = MagicMock()

--- a/tests/client/transports/test_jsonrpc_client.py
+++ b/tests/client/transports/test_jsonrpc_client.py
@@ -212,6 +212,61 @@ class TestSendMessage:
         assert response.HasField('message')
         assert response.message.message_id == 'msg-1'
 
+    @pytest.mark.asyncio
+    async def test_send_message_unwrapped_with_kind_task(
+        self, transport, mock_httpx_client
+    ):
+        """A spec-compliant peer (e.g. another language SDK) sends the
+        Task unwrapped but with a "kind" discriminator field, which our
+        protobuf-generated Task type doesn't declare. It must be
+        stripped rather than break parsing.
+        """
+        task_id = str(uuid4())
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'jsonrpc': '2.0',
+            'id': '1',
+            'result': {
+                'id': task_id,
+                'kind': 'task',
+                'contextId': 'ctx-123',
+                'status': {'state': 'TASK_STATE_COMPLETED'},
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_httpx_client.send.return_value = mock_response
+
+        request = create_send_message_request()
+        response = await transport.send_message(request)
+
+        assert response.HasField('task')
+        assert response.task.id == task_id
+
+    @pytest.mark.asyncio
+    async def test_send_message_unwrapped_with_kind_message(
+        self, transport, mock_httpx_client
+    ):
+        """Same as above, but for a peer's unwrapped Message with kind."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'jsonrpc': '2.0',
+            'id': '1',
+            'result': {
+                'messageId': 'msg-1',
+                'kind': 'message',
+                'role': 'ROLE_AGENT',
+                'parts': [{'text': 'hi'}],
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_httpx_client.send.return_value = mock_response
+
+        request = create_send_message_request()
+        response = await transport.send_message(request)
+
+        assert response.HasField('message')
+        assert response.message.message_id == 'msg-1'
+
     @pytest.mark.parametrize(
         'error_cls, error_code', JSON_RPC_ERROR_CODE_MAP.items()
     )

--- a/tests/client/transports/test_jsonrpc_client.py
+++ b/tests/client/transports/test_jsonrpc_client.py
@@ -155,6 +155,63 @@ class TestSendMessage:
         payload = call_args[1]['json']
         assert payload['method'] == 'SendMessage'
 
+    @pytest.mark.asyncio
+    async def test_send_message_legacy_wrapped_task(
+        self, transport, mock_httpx_client
+    ):
+        """A peer that still nests the payload under the streaming
+        SendMessageResponse oneof (older SDKs, other language
+        implementations) should still be parsed correctly.
+        """
+        task_id = str(uuid4())
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'jsonrpc': '2.0',
+            'id': '1',
+            'result': {
+                'task': {
+                    'id': task_id,
+                    'contextId': 'ctx-123',
+                    'status': {'state': 'TASK_STATE_COMPLETED'},
+                }
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_httpx_client.send.return_value = mock_response
+
+        request = create_send_message_request()
+        response = await transport.send_message(request)
+
+        assert response.HasField('task')
+        assert response.task.id == task_id
+        assert response.task.status.state == TaskState.TASK_STATE_COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_send_message_legacy_wrapped_message(
+        self, transport, mock_httpx_client
+    ):
+        """Same as above, but for a peer returning a wrapped Message."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'jsonrpc': '2.0',
+            'id': '1',
+            'result': {
+                'message': {
+                    'messageId': 'msg-1',
+                    'role': 'ROLE_AGENT',
+                    'parts': [{'text': 'hi'}],
+                }
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_httpx_client.send.return_value = mock_response
+
+        request = create_send_message_request()
+        response = await transport.send_message(request)
+
+        assert response.HasField('message')
+        assert response.message.message_id == 'msg-1'
+
     @pytest.mark.parametrize(
         'error_cls, error_code', JSON_RPC_ERROR_CODE_MAP.items()
     )

--- a/tests/integration/test_client_server_integration.py
+++ b/tests/integration/test_client_server_integration.py
@@ -650,11 +650,11 @@ async def test_json_transport_base_client_send_message_with_extensions(
     with patch.object(
         transport, '_send_request', new_callable=AsyncMock
     ) as mock_send_request:
-        # Mock returns a JSON-RPC response with SendMessageResponse structure
+        # Mock returns a JSON-RPC response with the Task returned directly.
         mock_send_request.return_value = {
             'id': '123',
             'jsonrpc': '2.0',
-            'result': {'task': MessageToDict(TASK_FROM_BLOCKING)},
+            'result': MessageToDict(TASK_FROM_BLOCKING),
         }
 
         service_params = ServiceParametersFactory.create(

--- a/tests/integration/test_tenant.py
+++ b/tests/integration/test_tenant.py
@@ -90,7 +90,7 @@ class TestTenantDecorator:
         mock_httpx.send.return_value = MagicMock(
             status_code=200,
             json=lambda: {
-                'result': {'message': {}},
+                'result': {},
                 'id': '1',
                 'jsonrpc': '2.0',
             },

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -350,9 +350,8 @@ def test_send_message(client: TestClient, handler: mock.AsyncMock):
     assert response.status_code == 200
     data = response.json()
     assert 'result' in data
-    # Result is wrapped in SendMessageResponse with task field
-    assert data['result']['task']['id'] == 'task1'
-    assert data['result']['task']['status']['state'] == 'TASK_STATE_SUBMITTED'
+    assert data['result']['id'] == 'task1'
+    assert data['result']['status']['state'] == 'TASK_STATE_SUBMITTED'
 
     # Verify handler was called
     handler.on_message_send.assert_awaited_once()
@@ -536,8 +535,7 @@ def test_server_auth(app, handler: mock.AsyncMock):
     assert response.status_code == 200
     data = response.json()
     assert 'result' in data
-    # Result is wrapped in SendMessageResponse with message field
-    assert data['result']['message']['parts'][0]['text'] == 'test_user'
+    assert data['result']['parts'][0]['text'] == 'test_user'
 
     # Verify handler was called
     handler.on_message_send.assert_awaited_once()


### PR DESCRIPTION
**Fixes** #1192

Right now message/send on the JSON-RPC transport returns the result nested one level too deep, like {"task": {...}} instead of just the Task object. Turns out jsonrpc_dispatcher.py was wrapping the return value in a SendMessageResponse before serializing it, but that oneof is meant for the streaming StreamResponse, not for the unary send. tasks/get and tasks/cancel already return their payload unwrapped, so message/send was the one behaving differently, and any client that follows the spec and reads result.status or result.artifacts just gets nothing back.

Fixed _handle_send_message to serialize task_or_message directly, same as the get/cancel handlers do.

While testing this I ran into something the original issue didn't mention: the client side transport (JsonRpcTransport.send_message) parses the result straight into a SendMessageResponse object, which only knows about the task/message fields. Once the server stopped wrapping the response, this started throwing a ParseError because fields like id and status don't exist on SendMessageResponse. So a client and server from this same SDK would break talking to each other after the fix.

I extended the client transport to handle this, then kept finding more shapes once I ran it against the ITK cross-SDK suite, which spins up real Go and Python peer implementations instead of mocks. Turns out real peers send the payload in at least three different shapes: the old wrapped {"task": {...}}, the new unwrapped shape this fix produces, and a spec-compliant unwrapped shape that carries a "kind": "task"/"message" discriminator on every Task, Message, and Part in the tree, including status.message, history entries, and message parts, none of which our protobuf-generated types declare. The client now checks for the wrapped shape first, then reads or infers the kind, strips it recursively from the whole payload, and parses into Task or Message accordingly, wrapping the result back into a SendMessageResponse so nothing downstream in BaseClient has to change. The v0.3 compat transport already does something similar for its own wire format, this just applies the same idea to the 1.0 JSON-RPC path.

One thing I want to flag instead of quietly leaving out: two ITK scenarios still fail after all of this, Star Topology Full JSONRPC & GRPC and Push Notification Test JSONRPC & GRPC, both specifically on the leg where current calls go_v10 over unary JSON-RPC. I went through the full raw logs and there is no exception anywhere, current's response to that call just comes back short. The same call to the same peer completes fully over grpc and http_json in the same run. Best explanation I have is that grpc always runs in streaming mode in itk/main.py so it waits for the terminal event, go_v10's REST handler evidently blocks until the task is done, but its JSON-RPC handler returns before the task completes. That is not a response shape bug, it looks like an async lifecycle behavior specific to go_v10's JSON-RPC handler, or a gap in the ITK test agent not polling after a non-terminal response, and either way it lives outside this repo. I do not think it should block this PR since what #1192 asked for is fixed and tested, but wanted to leave a clear trail in case a maintainer wants to chase it further or file it against a2a-go or a2a-itk.

**Changed files:**

src/a2a/server/routes/jsonrpc_dispatcher.py, the actual fix
src/a2a/client/transports/jsonrpc.py, client side parsing update covering the legacy wrapper, the kind discriminator, and the recursive strip
tests/client/transports/test_jsonrpc_client.py, new tests for the wrapped shape and for kind-discriminated payloads, both flat and nested
tests/server/test_integration.py
tests/integration/test_client_server_integration.py
tests/client/test_auth_interceptor.py
tests/integration/test_tenant.py

those last four just had mocks or assertions updated to match the new unwrapped shape.

**Test plan:**

ran the full suite, 1795 passed, nothing broken
ruff check and ruff format --check both clean
manually confirmed the round trip test that broke when I only fixed the server side now passes with both sides updated
ran against the ITK cross-SDK suite, went from 8 failing scenarios to 2, the remaining 2 are the go_v10 JSON-RPC timing issue described above, unrelated to response shape.
