### PR TITLE
fix: inherit stored task context id

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler_v2.py
+++ b/src/a2a/server/request_handlers/default_request_handler_v2.py
@@ -221,6 +221,8 @@ class DefaultRequestHandlerV2(RequestHandler):
             task = await self.task_store.get(original_task_id, call_context)
             if not task:
                 raise TaskNotFoundError(f'Task {original_task_id} not found')
+            if not original_context_id:
+                original_context_id = task.context_id
 
         # Build context to resolve or generate missing IDs
         request_context = await self._request_context_builder.build(

--- a/tests/server/request_handlers/test_default_request_handler_v2.py
+++ b/tests/server/request_handlers/test_default_request_handler_v2.py
@@ -969,6 +969,7 @@ async def test_on_message_send_task_in_terminal_state(terminal_state):
         task_id=task_id, status_state=terminal_state
     )
     mock_task_store = AsyncMock(spec=TaskStore)
+    mock_task_store.get.return_value = terminal_task
     request_handler = DefaultRequestHandlerV2(
         agent_executor=MockAgentExecutor(),
         task_store=mock_task_store,
@@ -1008,6 +1009,7 @@ async def test_on_message_send_stream_task_in_terminal_state(terminal_state):
         task_id=task_id, status_state=terminal_state
     )
     mock_task_store = AsyncMock(spec=TaskStore)
+    mock_task_store.get.return_value = terminal_task
     request_handler = DefaultRequestHandlerV2(
         agent_executor=MockAgentExecutor(),
         task_store=mock_task_store,
@@ -1036,6 +1038,40 @@ async def test_on_message_send_stream_task_in_terminal_state(terminal_state):
         f'Task {task_id} is in terminal state: {terminal_state}'
         in exc_info.value.message
     )
+
+
+@pytest.mark.asyncio
+async def test_setup_active_task_inherits_stored_task_context_id():
+    """A task-only continuation must retain its existing conversation context."""
+    task_id = 'existing_task'
+    stored_task = create_sample_task(
+        task_id=task_id, context_id='stored_context'
+    )
+    task_store = AsyncMock(spec=TaskStore)
+    task_store.get.return_value = stored_task
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=MockAgentExecutor(),
+        task_store=task_store,
+        agent_card=create_default_agent_card(),
+    )
+    request_handler._active_task_registry.get_or_create = AsyncMock()
+    params = SendMessageRequest(
+        message=Message(
+            role=Role.ROLE_USER,
+            message_id='continue_existing_task',
+            parts=[Part(text='continue')],
+            task_id=task_id,
+        )
+    )
+    call_context = create_server_call_context()
+
+    _, request_context = await request_handler._setup_active_task(
+        params, call_context
+    )
+
+    assert request_context.context_id == stored_task.context_id
+    assert params.message.context_id == stored_task.context_id
+    task_store.get.assert_awaited_once_with(task_id, call_context)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

When a V2 message continues an existing task with `taskId` but omits
`contextId`, the handler fetches the stored task but previously allowed the
request context to generate a new context ID.

This patch carries the stored task's context ID into request-context
construction while continuing to defer loading the mutable task into the
executor context. A focused regression verifies that both the request context
and message retain the stored conversation context.

Validation:

- Pre-fix regression failed because a generated UUID replaced
  `stored_context`.
- Focused regression: 1 passed.
- V2 request-handler suite: 65 passed.
- `./scripts/lint.sh`: passed (three pre-existing `ty` unused-ignore warnings).
- `uv run pytest`: 1970 passed, 90 skipped, 3 xfailed, 1 xpassed.
- `uv run pytest --cov=src --cov-report=term-missing`: 1970 passed, 90 skipped,
  3 xfailed, 1 xpassed. Database-backed tests skipped because their optional
  test DSNs were not configured.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make the Pull Request title follow the Conventional Commits specification.
- [x] Ensure the tests and linter pass.
- [x] Appropriate docs were updated (not needed for this behavioral fix).

Fixes #1206 🦕
