### PR TITLE
fix: flush the last SSE event when the stream ends without a blank line

### DIFF
--- a/src/a2a/client/transports/http_helpers.py
+++ b/src/a2a/client/transports/http_helpers.py
@@ -102,6 +102,9 @@ async def parse_sse_stream(
         elif key == 'data':
             payload_chunks.append(val)
 
+    if payload_chunks:
+        yield event_name, '\n'.join(payload_chunks)
+
 
 async def send_http_stream_request(
     httpx_client: httpx.AsyncClient,

--- a/tests/client/transports/test_http_helpers.py
+++ b/tests/client/transports/test_http_helpers.py
@@ -39,6 +39,18 @@ async def test_parse_sse_stream_edge_cases():
 
 
 @pytest.mark.asyncio
+async def test_parse_sse_stream_flushes_last_event_without_blank_line():
+    async def mock_aiter_lines():
+        yield 'data: {"task":{"id":"t1"}}\n'
+
+    response = httpx.Response(200)
+    response.aiter_lines = mock_aiter_lines  # type: ignore
+
+    events = [e async for e in parse_sse_stream(response)]
+    assert events == [('message', '{"task":{"id":"t1"}}')]
+
+
+@pytest.mark.asyncio
 async def test_send_http_stream_request_non_sse(mocker):
     client = httpx.AsyncClient()
     request = httpx.Request('GET', 'http://test')


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #1213

## Summary

`parse_sse_stream` only yields on a blank line. If the peer closes after `data: {...}` with no trailing blank line, leftover payload is dropped.

WHATWG SSE requires dispatching a pending event when the connection closes. JsonRpcTransport and RestTransport both use this parser, so a completed Task or Message can vanish and the client waits as if the stream is still open.

After the `aiter_lines` loop, if `payload_chunks` is non-empty, the pending event is now yielded the same way a blank line would. Existing tests already send a trailing newline and stay green.

## Testing

Added `test_parse_sse_stream_flushes_last_event_without_blank_line` in `tests/client/transports/test_http_helpers.py`.

```
uv run pytest tests/client/transports/test_http_helpers.py -q
```

4 passed.