### PR TITLE
fix: do not treat TASK_STATE_UNSPECIFIED as a terminal event

### DIFF
--- a/src/a2a/server/events/event_consumer.py
+++ b/src/a2a/server/events/event_consumer.py
@@ -75,7 +75,6 @@ class EventConsumer:
                         TaskState.TASK_STATE_CANCELED,
                         TaskState.TASK_STATE_FAILED,
                         TaskState.TASK_STATE_REJECTED,
-                        TaskState.TASK_STATE_UNSPECIFIED,
                         TaskState.TASK_STATE_INPUT_REQUIRED,
                     )
                 )

--- a/tests/server/events/test_event_consumer.py
+++ b/tests/server/events/test_event_consumer.py
@@ -104,6 +104,43 @@ async def test_consume_all_multiple_events(
 
 
 @pytest.mark.asyncio
+async def test_consume_all_does_not_stop_on_unspecified_state(
+    event_consumer: MagicMock,
+    mock_event_queue: MagicMock,
+):
+    events: list[Any] = [
+        Task(id='task_123', context_id='session-xyz'),
+        TaskStatusUpdateEvent(
+            task_id='task_123',
+            context_id='session-xyz',
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+        ),
+        TaskStatusUpdateEvent(
+            task_id='task_123',
+            context_id='session-xyz',
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+        ),
+    ]
+    cursor = 0
+
+    async def mock_dequeue() -> Any:
+        nonlocal cursor
+        if cursor < len(events):
+            event = events[cursor]
+            cursor += 1
+            return event
+        mock_event_queue.is_closed.return_value = True
+        raise asyncio.QueueEmpty()
+
+    mock_event_queue.dequeue_event = mock_dequeue
+    consumed_events: list[Any] = []
+    async for event in event_consumer.consume_all():
+        consumed_events.append(event)
+    assert consumed_events == events
+    assert mock_event_queue.task_done.call_count == 3
+
+
+@pytest.mark.asyncio
 async def test_consume_until_message(
     event_consumer: MagicMock,
     mock_event_queue: MagicMock,


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #1214

## Summary

Legacy `EventConsumer.is_final_event` included `TASK_STATE_UNSPECIFIED` in the stop set. That is the proto default (value 0), not a finished state.

Spec 4.1.3 treats unspecified as unknown. Terminal is COMPLETED, FAILED, CANCELED, REJECTED. V2 `TERMINAL_TASK_STATES` already omits unspecified. `INPUT_REQUIRED` is left alone because consume_all still pauses there on the legacy path.

If an agent enqueues a Task without setting status, or a status update that omits state, the queue closed and later WORKING/COMPLETED events never reached message/send, stream, cancel, or subscribe.

UNSPECIFIED is removed from the terminal set so a default-state Task no longer stops the loop.

## Testing

Added `test_consume_all_does_not_stop_on_unspecified_state`.

```
uv run pytest tests/server/events/test_event_consumer.py -q
```

16 passed, 2 xfailed (existing #869).