### PR TITLE
fix(server): drop stale ActiveTask snapshot when reusing an idle task

### DIFF
--- a/src/a2a/server/agent_execution/active_task.py
+++ b/src/a2a/server/agent_execution/active_task.py
@@ -419,6 +419,17 @@ class ActiveTask:
         """The ID of the task."""
         return self._task_id
 
+    def refresh_on_reuse(self) -> None:
+        """Drops the cached task snapshot when the task is idle.
+
+        Forces the next request to re-read the store instead of resuming from a
+        stale pre-interrupt snapshot. Skipped while a subscriber stream is in
+        flight (`_reference_count > 1`), since re-reading mid-stream would lose
+        the open artifact.
+        """
+        if self._reference_count <= 1:
+            self._task_manager.invalidate_cached_task()
+
     async def enqueue_request(
         self, request_context: RequestContext
     ) -> uuid.UUID:

--- a/src/a2a/server/agent_execution/active_task_registry.py
+++ b/src/a2a/server/agent_execution/active_task_registry.py
@@ -52,6 +52,11 @@ class ActiveTaskRegistry:
             if self._closed:
                 raise RuntimeError('ActiveTaskRegistry is closed')
             existing = self._active_tasks.get(task_id)
+            if existing is not None:
+                # Drop the reused task's stale snapshot so the next request
+                # re-reads the store instead of overwriting another replica's
+                # writes. No-op while a subscriber stream is in flight.
+                existing.refresh_on_reuse()
             if existing is None:
                 task_manager = TaskManager(
                     task_id=task_id,

--- a/src/a2a/server/tasks/task_manager.py
+++ b/src/a2a/server/tasks/task_manager.py
@@ -155,6 +155,10 @@ class TaskManager:
             logger.debug('Task %s not found.', self.task_id)
         return self._current_task
 
+    def invalidate_cached_task(self) -> None:
+        """Drops the cached snapshot so the next `get_task` re-reads the store."""
+        self._current_task = None
+
     async def save_task_event(
         self, event: Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent
     ) -> Task | None:

--- a/tests/server/agent_execution/test_active_task.py
+++ b/tests/server/agent_execution/test_active_task.py
@@ -73,6 +73,28 @@ class TestActiveTask:
         )
 
     @pytest.mark.asyncio
+    async def test_refresh_on_reuse_drops_snapshot_when_idle(
+        self, active_task: ActiveTask, task_manager: Mock
+    ) -> None:
+        """An idle reused task (reference_count <= 1) invalidates its snapshot."""
+        active_task._reference_count = 1
+
+        active_task.refresh_on_reuse()
+
+        task_manager.invalidate_cached_task.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_refresh_on_reuse_keeps_snapshot_when_streaming(
+        self, active_task: ActiveTask, task_manager: Mock
+    ) -> None:
+        """A task with an in-flight subscriber keeps its snapshot."""
+        active_task._reference_count = 2
+
+        active_task.refresh_on_reuse()
+
+        task_manager.invalidate_cached_task.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_active_task_already_started(
         self, active_task: ActiveTask, request_context: Mock
     ) -> None:

--- a/tests/server/agent_execution/test_active_task_registry.py
+++ b/tests/server/agent_execution/test_active_task_registry.py
@@ -170,3 +170,91 @@ async def test_get_or_create_cache_hit_is_owner_scoped():
     assert again is active
 
     await registry.aclose()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_reused_idle_task_drops_stale_snapshot():
+    """Issue #1188: reusing an idle ActiveTask after a non-terminal interrupt
+    must drop its cached TaskManager snapshot, so the per-request get_task()
+    in _run_producer re-reads the store instead of resuming from a
+    pre-interrupt snapshot that would overwrite state another replica wrote.
+    """
+    store = InMemoryTaskStore()
+    registry = ActiveTaskRegistry(
+        agent_executor=_SlowExecutor(), task_store=store
+    )
+    ctx = _ctx('alice')
+
+    await store.save(
+        Task(
+            id='task-1',
+            status=TaskStatus(state=TaskState.TASK_STATE_INPUT_REQUIRED),
+        ),
+        ctx,
+    )
+    active = await registry.get_or_create(
+        'task-1', call_context=ctx, create_task_if_missing=True
+    )
+
+    # Simulate the producer having cached a pre-interrupt snapshot, then the
+    # task going idle (its previous request's subscriber has detached).
+    stale = Task(
+        id='task-1',
+        status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED),
+    )
+    active._task_manager._current_task = stale
+    assert active._reference_count == 1  # idle: no in-flight subscriber
+
+    reused = await registry.get_or_create(
+        'task-1', call_context=ctx, create_task_if_missing=False
+    )
+
+    assert reused is active
+    assert active._task_manager._current_task is None
+
+    await registry.aclose()
+
+
+@pytest.mark.timeout(5)
+@pytest.mark.asyncio
+async def test_reused_streaming_task_keeps_snapshot():
+    """Issue #1188 guard: a reused ActiveTask with a subscriber stream still in
+    flight (reference_count > 1) must KEEP its snapshot. Re-reading the store
+    mid-stream would drop the open artifact and the next append=True chunk
+    would fail with InvalidAgentResponseError.
+    """
+    store = InMemoryTaskStore()
+    registry = ActiveTaskRegistry(
+        agent_executor=_SlowExecutor(), task_store=store
+    )
+    ctx = _ctx('alice')
+
+    await store.save(
+        Task(
+            id='task-1',
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+        ),
+        ctx,
+    )
+    active = await registry.get_or_create(
+        'task-1', call_context=ctx, create_task_if_missing=True
+    )
+
+    snapshot = Task(
+        id='task-1',
+        status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+    )
+    active._task_manager._current_task = snapshot
+    # Simulate an in-flight subscriber tailing the current stream.
+    active._reference_count = 2
+
+    reused = await registry.get_or_create(
+        'task-1', call_context=ctx, create_task_if_missing=False
+    )
+
+    assert reused is active
+    assert active._task_manager._current_task is snapshot
+
+    active._reference_count = 1
+    await registry.aclose()

--- a/tests/server/tasks/test_task_manager.py
+++ b/tests/server/tasks/test_task_manager.py
@@ -112,6 +112,28 @@ async def test_get_task_nonexistent(
 
 
 @pytest.mark.asyncio
+async def test_invalidate_cached_task_forces_store_reread(
+    task_manager: TaskManager, mock_task_store: AsyncMock
+) -> None:
+    """After invalidation, get_task re-reads the store instead of returning the
+    cached snapshot (issue #1188)."""
+    stale = create_minimal_task()
+    fresh = create_minimal_task()
+    fresh.status.state = TaskState.TASK_STATE_INPUT_REQUIRED
+    mock_task_store.get.return_value = fresh
+
+    # Prime the cache; a second get_task without invalidation stays cached.
+    task_manager._current_task = stale
+    assert await task_manager.get_task() is stale
+    mock_task_store.get.assert_not_called()
+
+    task_manager.invalidate_cached_task()
+
+    assert await task_manager.get_task() is fresh
+    mock_task_store.get.assert_called_once_with(MINIMAL_TASK_ID, TEST_CONTEXT)
+
+
+@pytest.mark.asyncio
 async def test_save_task_event_new_task(
     task_manager: TaskManager, mock_task_store: AsyncMock
 ) -> None:


### PR DESCRIPTION
# Description

Fixes a silent data-loss bug in `DefaultRequestHandlerV2` (`ActiveTaskRegistry`) for multi-replica deployments.

A reused `ActiveTask` keeps its `TaskManager._current_task` snapshot across non-terminal interrupts (`input_required` / `auth_required`) — cleanup only runs on terminal states. The per-request `get_task()` in `_run_producer` intends to refresh the task each request (see the existing `# TODO: Should we create task manager every time?`), but `get_task()` short-circuits on the cached snapshot, so the refresh is a no-op.

With more than one replica sharing a `TaskStore` and no task affinity, a resume routed back to the pod holding the stale snapshot silently overwrites artifacts, history and status that another replica persisted while the task was parked. There is no error — the save succeeds and the client simply sees the other replica's artifacts disappear.

## Fix

When the registry reuses an **idle** `ActiveTask` (`_reference_count <= 1`, i.e. no subscriber stream in flight), drop the cached snapshot so the next request re-reads the store at the request boundary. This matches the intent of the existing TODO while preserving V2's per-task serialization and streaming semantics.

A still-streaming task (`_reference_count > 1`) keeps its snapshot on purpose: re-reading the store mid-stream would lose the open artifact and make the next `append=True` chunk fail with `InvalidAgentResponseError`.

This follows the approach suggested by the maintainer in the issue (folding the downstream `FreshTaskRegistry` workaround into the SDK).

Changes:
- `TaskManager.invalidate_cached_task()` — drops the cached snapshot so the next `get_task()` re-reads the store.
- `ActiveTask.refresh_on_reuse()` — invalidates the snapshot only when the task is idle.
- `ActiveTaskRegistry.get_or_create()` — calls `refresh_on_reuse()` on the cache-hit path.

## Tests

- `test_task_manager.py`: invalidation forces a fresh store read.
- `test_active_task.py`: `refresh_on_reuse` drops the snapshot when idle, keeps it while streaming.
- `test_active_task_registry.py`: a reused idle task drops its stale snapshot; a reused streaming task keeps it.

## Out of scope

Concurrent writes from two replicas to the same task still race (last-writer-wins at the `TaskStore`). Addressing that needs a store-level version / compare-and-swap contract and is tracked separately in the issue.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `bash scripts/format.sh` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1188 🦕
