### PR TITLE
fix: compare in-memory task timestamps numerically

### DIFF
--- a/src/a2a/server/tasks/inmemory_task_store.py
+++ b/src/a2a/server/tasks/inmemory_task_store.py
@@ -93,8 +93,8 @@ class _InMemoryTaskStoreImpl(TaskStore):
                 task for task in tasks if task.status.state == params.status
             ]
         if params.HasField('status_timestamp_after'):
-            last_updated_after_iso = (
-                params.status_timestamp_after.ToJsonString()
+            last_updated_after_ns = (
+                params.status_timestamp_after.ToNanoseconds()
             )
             tasks = [
                 task
@@ -102,8 +102,8 @@ class _InMemoryTaskStoreImpl(TaskStore):
                 if (
                     task.HasField('status')
                     and task.status.HasField('timestamp')
-                    and task.status.timestamp.ToJsonString()
-                    >= last_updated_after_iso
+                    and task.status.timestamp.ToNanoseconds()
+                    >= last_updated_after_ns
                 )
             ]
 
@@ -113,9 +113,9 @@ class _InMemoryTaskStoreImpl(TaskStore):
                 task.status.HasField('timestamp')
                 if task.HasField('status')
                 else False,
-                task.status.timestamp.ToJsonString()
+                task.status.timestamp.ToNanoseconds()
                 if task.HasField('status') and task.status.HasField('timestamp')
-                else '',
+                else 0,
                 task.id,
             ),
             reverse=True,

--- a/tests/server/tasks/test_inmemory_task_store.py
+++ b/tests/server/tasks/test_inmemory_task_store.py
@@ -258,6 +258,91 @@ async def test_list_tasks_fails(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'task_time, threshold, included',
+    [
+        ('00Z', '00.001Z', False),
+        ('00.001Z', '00Z', True),
+        ('00.123Z', '00.123001Z', False),
+        ('00.123001Z', '00.123Z', True),
+        ('00.123Z', '00.123000001Z', False),
+        ('00.123000001Z', '00.123Z', True),
+        ('00.123001Z', '00.123001001Z', False),
+        ('00.123001001Z', '00.123001Z', True),
+        ('00.123Z', '00.123Z', True),
+        ('00.123000001Z', '00.123000001Z', True),
+        ('00.999999999Z', '01Z', False),
+        ('01Z', '00.999999999Z', True),
+    ],
+)
+async def test_list_tasks_timestamp_filter_precision(
+    task_time: str, threshold: str, included: bool
+) -> None:
+    """Compare timestamp values across JSON fractional-second precisions."""
+    store = InMemoryTaskStore()
+    task = create_minimal_task()
+    task.status.timestamp.FromJsonString(f'2025-01-01T00:00:{task_time}')
+    await store.save(task, TEST_CONTEXT)
+    await store.save(create_minimal_task('no-timestamp'), TEST_CONTEXT)
+    await store.save(Task(id='no-status'), TEST_CONTEXT)
+    params = ListTasksRequest()
+    params.status_timestamp_after.FromJsonString(
+        f'2025-01-01T00:00:{threshold}'
+    )
+
+    page = await store.list(params, TEST_CONTEXT)
+
+    assert [result.id for result in page.tasks] == (
+        [task.id] if included else []
+    )
+    assert page.total_size == int(included)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('page_size', [1, 3, 20])
+async def test_list_tasks_timestamp_ordering_and_pagination(
+    page_size: int,
+) -> None:
+    """Keep chronological order and ID tie-breaking across page boundaries."""
+    store = InMemoryTaskStore()
+    # Chronological order, including timestamps before and at the Unix epoch.
+    timestamps = [
+        '1969-12-31T23:59:59.999999999Z',
+        '1970-01-01T00:00:00Z',
+        '2025-01-01T00:00:00Z',
+        '2025-01-01T00:00:00.123Z',
+        '2025-01-01T00:00:00.123000001Z',
+        '2025-01-01T00:00:00.123001Z',
+        '2025-01-01T00:00:00.123001001Z',
+        '2025-01-01T00:00:01Z',
+        '2025-01-01T00:00:01Z',
+    ]
+    for index, timestamp in enumerate(timestamps):
+        task = create_minimal_task(f'task-{index}')
+        task.status.timestamp.FromJsonString(timestamp)
+        await store.save(task, TEST_CONTEXT)
+    await store.save(create_minimal_task('no-timestamp'), TEST_CONTEXT)
+    await store.save(Task(id='no-status'), TEST_CONTEXT)
+    expected_ids = [
+        *(f'task-{index}' for index in reversed(range(len(timestamps)))),
+        'no-timestamp',
+        'no-status',
+    ]
+    params = ListTasksRequest(page_size=page_size)
+
+    for start in range(0, len(expected_ids), page_size):
+        page = await store.list(params, TEST_CONTEXT)
+        assert [task.id for task in page.tasks] == expected_ids[
+            start : start + page_size
+        ]
+        assert page.total_size == len(expected_ids)
+        assert bool(page.next_page_token) == (
+            start + page_size < len(expected_ids)
+        )
+        params.page_token = page.next_page_token
+
+
+@pytest.mark.asyncio
 async def test_in_memory_task_store_delete() -> None:
     """Test deleting a task from the store."""
     store = InMemoryTaskStore()


### PR DESCRIPTION
# Description

Fix timestamp filtering and descending ordering in `InMemoryTaskStore.list()`. Comparing `ToJsonString()` values lexicographically reverses chronological order when fractional-second precision differs. For example, `2025-01-01T00:00:00.123Z` incorrectly passes a filter whose threshold is `2025-01-01T00:00:00.123000001Z`, despite being one nanosecond earlier. The same comparison also produces incorrectly ordered pages.

Compare integer nanoseconds using `ToNanoseconds()` for both filtering and sorting. Preserve the inclusive filter boundary, descending ID tie-breaker, and placement of tasks without timestamps after timestamped tasks.

[A2A specification §5.6.1, Timestamps](https://a2a-protocol.org/latest/specification/#561-timestamps) states: “Millisecond precision SHOULD be used where available”. It also specifies `google.protobuf.Timestamp`, whose representation contains seconds and nanoseconds, and permits omitted fractional seconds. Numeric comparison handles these precisions without discarding sub-millisecond information.

Add 15 regression cases covering seconds, milliseconds, microseconds, nanoseconds, equal timestamps, second boundaries, pagination, ID tie-breaking, absent timestamps/status, and timestamps before/at the Unix epoch. Before the fix, 11 cases fail and four pass; after the fix, all 35 in-memory task store tests pass.

Validation on Python 3.10 with PostgreSQL 15 and MySQL 8:

- `./scripts/lint.sh`: Ruff check/format and ty passed (three existing unused-ignore warnings outside this change).
- `uv run pytest`: 2,092 passed, 3 xfailed, 1 xpassed. The xfail/xpass cases are already marked for #869.
- `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=88`: same test results, 93.17% coverage.
- JSCPD: 2.61% duplication, below the 3% threshold.
- Built the wheel and ran `tests.install_smoke` in six clean environments: base, http-server, fastapi, grpc, telemetry, and sql all passed.

Local transport checks used proxy exclusions for loopback addresses. Cross-version `uv --with` environments were prepared before the full runs to keep dependency downloads outside server-startup timeouts.

- [x] Follow the CONTRIBUTING guide: feature branch based on current upstream main.
- [x] Conventional Commit title: `fix: compare in-memory task timestamps numerically`.
- [x] Tests and linters pass.
- [x] Protocol reference included above; no public API changes.
