### PR TITLE
fix(server): return the stored id when creating a push notification config

### DIFF
--- a/src/a2a/server/request_handlers/default_request_handler.py
+++ b/src/a2a/server/request_handlers/default_request_handler.py
@@ -547,6 +547,12 @@ class LegacyRequestHandler(RequestHandler):
 
         await self._reject_unsafe_push_url(params.url)
 
+        # Stores default an empty id to the task id, but only the in-memory
+        # store does so on the caller's object. Normalize here so the returned
+        # config carries the id that was persisted, on every store.
+        if not params.id:
+            params.id = task_id
+
         await self._push_config_store.set_info(
             task_id,
             params,

--- a/src/a2a/server/request_handlers/default_request_handler_v2.py
+++ b/src/a2a/server/request_handlers/default_request_handler_v2.py
@@ -385,6 +385,12 @@ class DefaultRequestHandlerV2(RequestHandler):
 
         await self._reject_unsafe_push_url(params.url)
 
+        # Stores default an empty id to the task id, but only the in-memory
+        # store does so on the caller's object. Normalize here so the returned
+        # config carries the id that was persisted, on every store.
+        if not params.id:
+            params.id = task_id
+
         await self._push_config_store.set_info(
             task_id,
             params,

--- a/tests/server/request_handlers/test_default_request_handler.py
+++ b/tests/server/request_handlers/test_default_request_handler.py
@@ -1936,6 +1936,50 @@ async def test_set_task_push_notification_config_task_not_found(agent_card):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('store_kind', ['inmemory', 'database'])
+async def test_create_task_push_notification_config_returns_stored_id(
+    agent_card, store_kind
+):
+    """Test on_create_task_push_notification_config returns the id that was stored."""
+    if store_kind == 'database':
+        from a2a.server.tasks.database_push_notification_config_store import (
+            DatabasePushNotificationConfigStore,
+        )
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        engine = create_async_engine(
+            'sqlite+aiosqlite:///file:pushid?mode=memory&cache=shared&uri=true'
+        )
+        push_config_store = DatabasePushNotificationConfigStore(engine=engine)
+    else:
+        push_config_store = InMemoryPushNotificationConfigStore()
+
+    task = create_sample_task()
+    task_store = InMemoryTaskStore()
+    context = create_server_call_context()
+    await task_store.save(task, context)
+
+    request_handler = DefaultRequestHandler(
+        agent_executor=MockAgentExecutor(),
+        task_store=task_store,
+        push_config_store=push_config_store,
+        agent_card=agent_card,
+    )
+    params = TaskPushNotificationConfig(
+        task_id=task.id,
+        url='http://example.com',
+    )
+
+    response = await request_handler.on_create_task_push_notification_config(
+        params, context
+    )
+
+    stored = await push_config_store.get_info(task.id, context)
+    assert response.id == task.id
+    assert [config.id for config in stored] == [response.id]
+
+
+@pytest.mark.asyncio
 async def test_get_task_push_notification_config_no_store(agent_card):
     """Test on_get_task_push_notification_config when _push_config_store is None."""
     request_handler = DefaultRequestHandler(

--- a/tests/server/request_handlers/test_default_request_handler_v2.py
+++ b/tests/server/request_handlers/test_default_request_handler_v2.py
@@ -512,6 +512,49 @@ async def test_set_task_push_notification_config_task_not_found():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('store_kind', ['inmemory', 'database'])
+async def test_create_task_push_notification_config_returns_stored_id(
+    store_kind,
+):
+    """Test on_create_task_push_notification_config returns the id that was stored."""
+    if store_kind == 'database':
+        from a2a.server.tasks.database_push_notification_config_store import (
+            DatabasePushNotificationConfigStore,
+        )
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        engine = create_async_engine(
+            'sqlite+aiosqlite:///file:pushidv2?mode=memory&cache=shared&uri=true'
+        )
+        push_config_store = DatabasePushNotificationConfigStore(engine=engine)
+    else:
+        push_config_store = InMemoryPushNotificationConfigStore()
+
+    task = create_sample_task()
+    task_store = InMemoryTaskStore()
+    context = create_server_call_context()
+    await task_store.save(task, context)
+
+    request_handler = DefaultRequestHandlerV2(
+        agent_executor=MockAgentExecutor(),
+        task_store=task_store,
+        push_config_store=push_config_store,
+        agent_card=create_default_agent_card(),
+    )
+    params = TaskPushNotificationConfig(
+        task_id=task.id, url='http://example.com'
+    )
+
+    response = await request_handler.on_create_task_push_notification_config(
+        params, context
+    )
+
+    stored = await push_config_store.get_info(task.id, context)
+    assert response.id == task.id
+    assert [config.id for config in stored] == [response.id]
+
+
+@pytest.mark.asyncio
 async def test_get_task_push_notification_config_no_store():
     """Test on_get_task_push_notification_config when _push_config_store is None."""
     request_handler = DefaultRequestHandlerV2(


### PR DESCRIPTION
## Problem

`on_create_task_push_notification_config` returns the caller's request object rather than what the store persisted. Both stores default an empty `id` to the task id, but the in-memory store does it on the caller's object and the database store does it on a private copy. So on a database-backed server the create response carries no `id`, and reading the config back with it raises `InvalidParamsError`.

## Fix

Normalize the id in both handlers before `set_info`, so the response matches what was stored on any store.

## Tests

`test_create_task_push_notification_config_returns_stored_id` in both handler test files, parametrized over the real in-memory and database stores. The `[database]` case fails with the source reverted.


Fixes #1237
